### PR TITLE
✨ Improvements with keybinds UIs and functionality

### DIFF
--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -27,16 +27,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             await Defaults.iCloud.waitForSyncCompletion()
         }
 
-        // Check & ask for accessibility access
-        AccessibilityManager.requestAccess()
-        UNUserNotificationCenter.current().delegate = self
-
-        AppDelegate.requestNotificationAuthorization()
-
-        IconManager.refreshCurrentAppIcon()
-        AppDelegate.loopManager.start()
-        AppDelegate.windowDragManager.addObservers()
-
         if !launchedAsLoginItem {
             LuminareManager.open()
         } else {
@@ -44,6 +34,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if !Defaults[.showDockIcon] {
                 NSApp.setActivationPolicy(.accessory)
             }
+        }
+
+        IconManager.refreshCurrentAppIcon()
+        AppDelegate.loopManager.start()
+        AppDelegate.windowDragManager.addObservers()
+
+        UNUserNotificationCenter.current().delegate = self
+        AppDelegate.requestNotificationAuthorization()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            AccessibilityManager.requestAccess()
         }
     }
 

--- a/Loop/Luminare/Settings/Keybindings/CustomActionConfigurationView.swift
+++ b/Loop/Luminare/Settings/Keybindings/CustomActionConfigurationView.swift
@@ -43,19 +43,19 @@ struct CustomActionConfigurationView: View {
     }
 
     var body: some View {
-        ScreenView {
+        ScreenView(blurred: .constant(action.sizeMode != .custom)) {
             GeometryReader { geo in
-                let frame = action.getFrame(window: nil, bounds: CGRect(origin: .zero, size: geo.size), disablePadding: true)
-                let _ = print(frame)
                 ZStack {
                     if action.sizeMode == .custom {
+                        let frame = action.getFrame(window: nil, bounds: CGRect(origin: .zero, size: geo.size), disablePadding: true)
+
                         blurredWindow()
                             .frame(width: frame.width, height: frame.height)
                             .offset(x: frame.origin.x, y: frame.origin.y)
+                            .animation(LuminareSettingsWindow.animation, value: frame)
                     }
                 }
                 .frame(width: geo.size.width, height: geo.size.height, alignment: .topLeading)
-                .animation(LuminareSettingsWindow.animation, value: frame)
             }
         }
         .onChange(of: action) { windowAction = $0 }
@@ -303,9 +303,9 @@ struct CustomActionConfigurationView: View {
     @ViewBuilder private func blurredWindow() -> some View {
         VisualEffectView(material: .hudWindow, blendingMode: .withinWindow)
             .overlay {
-                RoundedRectangle(cornerRadius: 5)
-                    .strokeBorder(.white.opacity(0.1), lineWidth: 2)
+                RoundedRectangle(cornerRadius: 12 - 5)
+                    .strokeBorder(Color.getLoopAccent(tone: .normal), lineWidth: 2)
             }
-            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .clipShape(RoundedRectangle(cornerRadius: 12 - 5))
     }
 }

--- a/Loop/Window Management/WindowAction+Image.swift
+++ b/Loop/Window Management/WindowAction+Image.swift
@@ -70,16 +70,6 @@ struct IconView: View {
                         .font(.system(size: 8))
                         .fontWeight(.bold)
                         .frame(width: size.width, height: size.height)
-                } else if action.direction == .cycle, action.cycle?.first == nil {
-                    Image(._18PxRepeat4)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: size.width, height: size.height)
-                } else if action.direction == .custom, frame == .zero {
-                    Image(._18PxSliders)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: size.width, height: size.height)
                 } else {
                     ZStack {
                         RoundedRectangle(cornerRadius: outerCornerRadius - inset)

--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -63,8 +63,8 @@ enum WindowEngine {
         let animate = Defaults[.animateWindowResizes] && !enhancedUI
         WindowRecords.record(window, action)
 
-        if window.nsRunningApplication == NSRunningApplication.current,
-           let window = NSApp.keyWindow {
+        if window.nsRunningApplication?.bundleIdentifier == Bundle.main.bundleIdentifier,
+           let window = NSApp.keyWindow ?? NSApp.windows.first {
             var newFrame = targetFrame
             newFrame.size = window.frame.size
 


### PR DESCRIPTION
I have also reordered functions in `applicationDidFinishLaunching()` within `AppDelegate` to ask for accessibility permits *after* the settings window is shown, so that the alert isn't immediately covered by Loop's settings window.