### PR TITLE
✨ Center fixed size windows within their target frame + Window resize code optimizations

### DIFF
--- a/Loop/Extensions/AXUIElement+Extensions.swift
+++ b/Loop/Extensions/AXUIElement+Extensions.swift
@@ -37,6 +37,15 @@ extension AXUIElement {
         }
     }
 
+    func canSetValue(_ attribute: NSAccessibility.Attribute) throws -> Bool {
+        var isSettable = DarwinBoolean(false)
+        let error = AXUIElementIsAttributeSettable(self, attribute as CFString, &isSettable)
+        guard error == .success else {
+            throw error
+        }
+        return isSettable.boolValue
+    }
+
     func getElementAtPosition(_ position: CGPoint) throws -> AXUIElement? {
         var element: AXUIElement?
         let error = AXUIElementCopyElementAtPosition(self, Float(position.x), Float(position.y), &element)

--- a/Loop/Extensions/CGGeometry+Extensions.swift
+++ b/Loop/Extensions/CGGeometry+Extensions.swift
@@ -52,6 +52,19 @@ extension CGSize {
     func approximatelyEqual(to size: CGSize, tolerance: CGFloat = 10) -> Bool {
         abs(width - size.width) < tolerance && abs(height - size.height) < tolerance
     }
+
+    func center(inside parentRect: CGRect) -> CGRect {
+        let parentRectCenter = parentRect.center
+        let newX = parentRectCenter.x - width / 2
+        let newY = parentRectCenter.y - height / 2
+
+        return CGRect(
+            x: newX,
+            y: newY,
+            width: width,
+            height: height
+        )
+    }
 }
 
 extension CGRect {
@@ -99,8 +112,16 @@ extension CGRect {
             abs(height - rect.height) < tolerance
     }
 
-    func pushBottomRightPointInside(_ rect2: CGRect) -> CGRect {
+    func pushInside(_ rect2: CGRect) -> CGRect {
         var result = self
+
+        if result.minX < rect2.minX {
+            result.origin.x = rect2.minX
+        }
+
+        if result.minY < rect2.minY {
+            result.origin.y = rect2.minY
+        }
 
         if result.maxX > rect2.maxX {
             result.origin.x = rect2.maxX - result.width

--- a/Loop/Managers/LoopManager.swift
+++ b/Loop/Managers/LoopManager.swift
@@ -14,7 +14,6 @@ class LoopManager: ObservableObject {
     // Size Adjustment
     static var sidesToAdjust: Edge.Set?
     static var lastTargetFrame: CGRect = .zero
-    static var canAdjustSize: Bool = true
 
     private let keybindMonitor = KeybindMonitor.shared
 
@@ -168,7 +167,6 @@ private extension LoopManager {
            isLoopActive {
             if let screenToResizeOn,
                Defaults[.previewVisibility] {
-                LoopManager.canAdjustSize = false
                 WindowEngine.resize(
                     targetWindow!,
                     to: currentAction,
@@ -191,7 +189,6 @@ private extension LoopManager {
         isLoopActive = false
         LoopManager.sidesToAdjust = nil
         LoopManager.lastTargetFrame = .zero
-        LoopManager.canAdjustSize = true
     }
 
     func openWindows() {

--- a/Loop/Managers/WindowDragManager.swift
+++ b/Loop/Managers/WindowDragManager.swift
@@ -104,7 +104,7 @@ class WindowDragManager {
         if let screen = NSScreen.screenWithMouse {
             var newWindowFrame = window.frame
             newWindowFrame.size = initialFrame.size
-            newWindowFrame = newWindowFrame.pushBottomRightPointInside(screen.frame)
+            newWindowFrame = newWindowFrame.pushInside(screen.frame)
             window.setFrame(newWindowFrame)
         } else {
             window.size = initialFrame.size

--- a/Loop/Window Management/Window.swift
+++ b/Loop/Window Management/Window.swift
@@ -255,6 +255,16 @@ class Window {
         }
     }
 
+    var isResizable: Bool {
+        do {
+            let result: Bool = try self.axWindow.canSetValue(.size)
+            return result
+        } catch {
+            print("Failed to get resizable: \(error.localizedDescription)")
+            return true
+        }
+    }
+
     var frame: CGRect {
         CGRect(origin: self.position, size: self.size)
     }

--- a/Loop/Window Management/Window.swift
+++ b/Loop/Window Management/Window.swift
@@ -28,7 +28,9 @@ class Window {
     let nsRunningApplication: NSRunningApplication?
 
     var observer: Observer?
-
+    
+    /// Initialize a window from an AXUIElement
+    /// - Parameter element: The AXUIElement to initialize the window with. If it is not a window, an error will be thrown
     init(element: AXUIElement) throws {
         self.axWindow = element
 
@@ -50,7 +52,9 @@ class Window {
             throw WindowError.invalidWindow
         }
     }
-
+    
+    /// Initialize a window from a PID. The frontmost app with the given PID will be used.
+    /// - Parameter pid: The PID of the app to get the window from
     convenience init(pid: pid_t) throws {
         let element = AXUIElementCreateApplication(pid)
         guard let window: AXUIElement = try element.getValue(.focusedWindow) else {
@@ -125,6 +129,8 @@ class Window {
         }
     }
 
+    
+    /// Activate the window. This will bring it to the front and focus it if possible
     func activate() {
         do {
             try self.axWindow.setValue(.main, value: true)
@@ -260,7 +266,7 @@ class Window {
             let result: Bool = try self.axWindow.canSetValue(.size)
             return result
         } catch {
-            print("Failed to get resizable: \(error.localizedDescription)")
+            print("Failed to determine if window size can be set: \(error.localizedDescription)")
             return true
         }
     }
@@ -268,12 +274,19 @@ class Window {
     var frame: CGRect {
         CGRect(origin: self.position, size: self.size)
     }
-
+    
+    /// Set the frame of this Window.
+    /// - Parameters:
+    ///   - rect: The new frame for the window
+    ///   - animate: Whether or not to animate the window resizing
+    ///   - sizeFirst: This will set the size first, which is useful when switching screens. Only does something when window animations are off
+    ///   - bounds: This will prevent the window from going outside the bounds. Only does something when window animations are on
+    ///   - completionHandler: Something to run after the window has been resized. This can include things like moving the cursor to the center of the window
     func setFrame(
         _ rect: CGRect,
         animate: Bool = false,
-        sizeFirst: Bool = false, // Only does something when window animations are off
-        bounds: CGRect = .zero, // Only does something when window animations are on
+        sizeFirst: Bool = false,
+        bounds: CGRect = .zero,
         completionHandler: @escaping (() -> ()) = {}
     ) {
         let enhancedUI = self.enhancedUserInterface

--- a/Loop/Window Management/Window.swift
+++ b/Loop/Window Management/Window.swift
@@ -28,7 +28,7 @@ class Window {
     let nsRunningApplication: NSRunningApplication?
 
     var observer: Observer?
-    
+
     /// Initialize a window from an AXUIElement
     /// - Parameter element: The AXUIElement to initialize the window with. If it is not a window, an error will be thrown
     init(element: AXUIElement) throws {
@@ -52,7 +52,7 @@ class Window {
             throw WindowError.invalidWindow
         }
     }
-    
+
     /// Initialize a window from a PID. The frontmost app with the given PID will be used.
     /// - Parameter pid: The PID of the app to get the window from
     convenience init(pid: pid_t) throws {
@@ -129,7 +129,6 @@ class Window {
         }
     }
 
-    
     /// Activate the window. This will bring it to the front and focus it if possible
     func activate() {
         do {
@@ -274,7 +273,7 @@ class Window {
     var frame: CGRect {
         CGRect(origin: self.position, size: self.size)
     }
-    
+
     /// Set the frame of this Window.
     /// - Parameters:
     ///   - rect: The new frame for the window

--- a/Loop/Window Management/WindowAction.swift
+++ b/Loop/Window Management/WindowAction.swift
@@ -139,7 +139,7 @@ struct WindowAction: Codable, Identifiable, Hashable, Equatable, Defaults.Serial
         }
 
         var bounds = bounds
-        var result = .zero
+        var result: CGRect = .zero
 
         // Get padded bounds only if padding can be applied
         if !disablePadding && Defaults[.enablePadding],
@@ -154,6 +154,13 @@ struct WindowAction: Codable, Identifiable, Hashable, Equatable, Defaults.Serial
         result = calculateTargetFrame(direction, window, bounds)
 
         if !disablePadding {
+            // If window can't be resized, center it within the already-resized frame.
+            if let window, window.isResizable == false {
+                result = window.frame.size
+                    .center(inside: result)
+                    .pushInside(bounds)
+            }
+
             // Apply padding between windows
             if direction != .undo, direction != .initialFrame {
                 result = applyInnerPadding(result, bounds)
@@ -171,7 +178,6 @@ struct WindowAction: Codable, Identifiable, Hashable, Equatable, Defaults.Serial
 // MARK: - Window Frame Calculations
 
 private extension WindowAction {
-
     func calculateTargetFrame(_ direction: WindowDirection, _ window: Window?, _ bounds: CGRect) -> CGRect {
         var result: CGRect = .zero
 

--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -70,22 +70,10 @@ enum WindowEngine {
 
         if window.nsRunningApplication?.bundleIdentifier == Bundle.main.bundleIdentifier,
            let window = NSApp.keyWindow ?? NSApp.windows.first {
-            var newFrame = targetFrame
-            newFrame.size = window.frame.size
-
-            if newFrame.maxX > screen.safeScreenFrame.maxX {
-                newFrame.origin.x = screen.safeScreenFrame.maxX - newFrame.width - Defaults[.padding].right
-            }
-
-            if newFrame.maxY > screen.safeScreenFrame.maxY {
-                newFrame.origin.y = screen.safeScreenFrame.maxY - newFrame.height - Defaults[.padding].bottom
-            }
-
             NSAnimationContext.runAnimationGroup { context in
                 context.timingFunction = CAMediaTimingFunction(controlPoints: 0.33, 1, 0.68, 1)
-                window.animator().setFrame(newFrame.flipY(screen: .screens[0]), display: false)
+                window.animator().setFrame(targetFrame.flipY(screen: .screens[0]), display: false)
             }
-
             return
         }
 

--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -64,10 +64,13 @@ enum WindowEngine {
             WindowRecords.removeLastAction(for: window)
         }
 
+        // If enhancedUI is enabled, then window animations will likely lag a LOT. So, if it's enabled, force-disable animations
         let enhancedUI = window.enhancedUserInterface
         let animate = Defaults[.animateWindowResizes] && !enhancedUI
+
         WindowRecords.record(window, action)
 
+        // If the window is one of Loop's windows, resize it using the actual NSWindow, preventing crashes
         if window.nsRunningApplication?.bundleIdentifier == Bundle.main.bundleIdentifier,
            let window = NSApp.keyWindow ?? NSApp.windows.first {
             NSAnimationContext.runAnimationGroup { context in
@@ -77,6 +80,8 @@ enum WindowEngine {
             return
         }
 
+        // If the window is being moved via shortcuts (move right, move left etc.), then the screenFrame will be zero.
+        // This is because the window *can* be moved off-screen in this case.
         let screenFrame = action.direction.willMove ? .zero : screen.safeScreenFrame
 
         let bounds = if Defaults[.enablePadding],
@@ -92,23 +97,25 @@ enum WindowEngine {
             sizeFirst: willChangeScreens,
             bounds: bounds
         ) {
-            // If animations are disabled, check if the window needs extra resizing
-            if !animate {
-                // Fixes an issue where window isn't resized correctly on multi-monitor setups
-                if !window.frame.approximatelyEqual(to: targetFrame) {
-                    print("Backup resizing...")
-                    window.setFrame(targetFrame)
-                }
+            // Fixes an issue where window isn't resized correctly on multi-monitor setups
+            // If window is being animated, then the size is very likely to already be correct, as what's really happening is window.setFrame at a really high rate.
+            if !animate, !window.frame.approximatelyEqual(to: targetFrame) {
+                print("Backup resizing...")
+                window.setFrame(targetFrame)
             }
 
+            // If window's minimum size exceeds the screen bounds, push it back in
             WindowEngine.handleSizeConstrainedWindow(window: window, bounds: bounds)
         }
 
+        // Move cursor to center of window if user has enabled it
         if Defaults[.moveCursorWithWindow] {
             CGWarpMouseCursorPosition(targetFrame.center)
         }
     }
 
+    /// Get the target window, depending on the user's preferences. This could be the frontmost window, or the window under the cursor.
+    /// - Returns: The target window
     static func getTargetWindow() -> Window? {
         var result: Window?
 
@@ -142,12 +149,17 @@ enum WindowEngine {
         return try Window(pid: app.processIdentifier)
     }
 
+    /// Get the Window at a given position.
+    /// - Parameter position: The position to check for
+    /// - Returns: The window at the given position, if any
     static func windowAtPosition(_ position: CGPoint) throws -> Window? {
+        // If we can find the window at a point using the Accessibility API, return it
         if let element = try AXUIElement.systemWide.getElementAtPosition(position),
            let windowElement: AXUIElement = try element.getValue(.window) {
             return try Window(element: windowElement)
         }
 
+        // If the previous method didn't work, loop through all windows on-screen and return the first one that contains the desired point
         let windowList = WindowEngine.windowList
         if let window = (windowList.first { $0.frame.contains(position) }) {
             return window
@@ -156,6 +168,7 @@ enum WindowEngine {
         return nil
     }
 
+    /// Get a list of all windows currently shown, that are likely to be resizable by Loop.
     static var windowList: [Window] {
         guard let list = CGWindowListCopyWindowInfo(
             [.optionOnScreenOnly, .excludeDesktopElements],
@@ -166,19 +179,20 @@ enum WindowEngine {
 
         var windowList: [Window] = []
         for window in list {
-            if let pid = window[kCGWindowOwnerPID as String] as? Int32 {
-                do {
-                    let window = try Window(pid: pid)
-                    windowList.append(window)
-                } catch {
-                    print("Failed to create window: \(error.localizedDescription)")
-                }
+            if let pid = window[kCGWindowOwnerPID as String] as? Int32, let window = try? Window(pid: pid) {
+                windowList.append(window)
             }
         }
 
         return windowList
     }
 
+    /// This function is used to calculate the Y offset for a window to be "macOS centered" on the screen
+    /// It is identical to `NSWindow.center()`.
+    /// - Parameters:
+    ///   - windowHeight: Height of the window to be resized
+    ///   - screenHeight: Height of the screen the window will be resized on
+    /// - Returns: The Y offset of the window, to be added onto the screen's midY point.
     static func getMacOSCenterYOffset(_ windowHeight: CGFloat, screenHeight: CGFloat) -> CGFloat {
         let halfScreenHeight = screenHeight / 2
         let windowHeightPercent = windowHeight / screenHeight

--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -72,7 +72,7 @@ enum WindowEngine {
 
         // If the window is one of Loop's windows, resize it using the actual NSWindow, preventing crashes
         if window.nsRunningApplication?.bundleIdentifier == Bundle.main.bundleIdentifier,
-           let window = NSApp.keyWindow ?? NSApp.windows.first {
+           let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.level.rawValue <= NSWindow.Level.floating.rawValue }) {
             NSAnimationContext.runAnimationGroup { context in
                 context.timingFunction = CAMediaTimingFunction(controlPoints: 0.33, 1, 0.68, 1)
                 window.animator().setFrame(targetFrame.flipY(screen: .screens[0]), display: false)

--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -30,17 +30,21 @@ enum WindowEngine {
             window.activate()
         }
 
+        // If window hasn't been recorded yet, record it, so that the user can undo the action
         if !WindowRecords.hasBeenRecorded(window) {
             WindowRecords.recordFirst(for: window)
         }
 
+        // If the action is fullscreen, toggle fullscreen then return
         if action.direction == .fullscreen {
             window.toggleFullscreen()
             WindowRecords.record(window, action)
             return
         }
+        // Otherwise, we obviously need to disable fullscreen to resize the window
         window.fullscreen = false
 
+        // If the action is to hide or minimize, perform the action then return
         if action.direction == .hide {
             window.toggleHidden()
             return
@@ -51,13 +55,14 @@ enum WindowEngine {
             return
         }
 
+        // Calculate the target frame
         let targetFrame = action.getFrame(window: window, bounds: screen.safeScreenFrame, screen: screen)
+        print("Target window frame: \(targetFrame)")
 
+        // If the action is undo, remove the last action from the window, as the target frame already contains the last action's size
         if action.direction == .undo {
             WindowRecords.removeLastAction(for: window)
         }
-
-        print("Target window frame: \(targetFrame)")
 
         let enhancedUI = window.enhancedUserInterface
         let animate = Defaults[.animateWindowResizes] && !enhancedUI


### PR DESCRIPTION
This will make sure that windows with fixed sizes (ex. Loop's settings window) will be centered within their calculated target frame. In addition, I have split window frame calculations into their own respective functions, which massively improves code readability :)