### PR TITLE
🐞 Fix window moving further than preview

### DIFF
--- a/Loop/Preview Window/LuminarePreviewView.swift
+++ b/Loop/Preview Window/LuminarePreviewView.swift
@@ -62,7 +62,7 @@ struct LuminarePreviewView: View {
             .offset(x: actionRect.minX, y: actionRect.minY)
             .scaleEffect(CGSize(width: scale, height: scale))
             .onAppear {
-                actionRect = action.getFrame(window: nil, bounds: .init(origin: .zero, size: geo.size))
+                actionRect = action.getFrame(window: nil, bounds: .init(origin: .zero, size: geo.size), isPreview: true)
 
                 withAnimation(
                     .interpolatingSpring(

--- a/Loop/Preview Window/PreviewController.swift
+++ b/Loop/Preview Window/PreviewController.swift
@@ -92,7 +92,8 @@ class PreviewController {
         let targetWindowFrame = action.getFrame(
             window: window,
             bounds: screen.safeScreenFrame,
-            screen: screen
+            screen: screen,
+            isPreview: true
         )
         .flipY(maxY: NSScreen.screens[0].frame.maxY)
 

--- a/Loop/Window Management/WindowAction.swift
+++ b/Loop/Window Management/WindowAction.swift
@@ -186,7 +186,7 @@ private extension WindowAction {
 
         } else if direction.willAdjustSize {
             // Return final frame of preview
-            if !isPreview {
+            if Defaults[.previewVisibility], !isPreview {
                 return LoopManager.lastTargetFrame
             }
 
@@ -196,7 +196,7 @@ private extension WindowAction {
 
         } else if direction.willShrink || direction.willGrow {
             // Return final frame of preview
-            if !isPreview {
+            if Defaults[.previewVisibility], !isPreview {
                 return LoopManager.lastTargetFrame
             }
 
@@ -219,7 +219,7 @@ private extension WindowAction {
 
         } else if direction.willMove {
             // Return final frame of preview
-            if !isPreview {
+            if Defaults[.previewVisibility], !isPreview {
                 return LoopManager.lastTargetFrame
             }
 


### PR DESCRIPTION
This PR introduces a `isPreview` argument for the `WindowAction.getFrame()` function to differentiate between calculating the preview and the target window. If the final frame for the target window gets calculated, the last action will be ignored because `LoopManager.lastTargetFrame` is already at the desired size/position.

Closes #462 