### PR TITLE
🐞 Fix crash when hiding or minimizing windows

### DIFF
--- a/Loop/Window Management/WindowAction.swift
+++ b/Loop/Window Management/WindowAction.swift
@@ -134,7 +134,8 @@ struct WindowAction: Codable, Identifiable, Hashable, Equatable, Defaults.Serial
     }
 
     func getFrame(window: Window?, bounds: CGRect, disablePadding: Bool = false, screen: NSScreen? = nil) -> CGRect {
-        guard direction != .cycle, direction != .noAction else {
+        let noFrameActions: [WindowDirection] = [.noAction, .cycle, .minimize, .hide]
+        guard !noFrameActions.contains(direction) else {
             return NSRect(origin: bounds.center, size: .zero)
         }
 


### PR DESCRIPTION
This fixes a bug where Loop would crash when trying to minimize or hide a window. This is because there is no "frame" for Loop to calculate (even though it was trying to get one) when it was trying to calculate a target frame.