### PR TITLE
✨ Add horizontal/vertical center half

### DIFF
--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -20067,6 +20067,17 @@
         }
       }
     },
+    "Window Direction/Name: Horizontal Center Half" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Horizontal Center Half"
+          }
+        }
+      }
+    },
     "Window Direction/Name: Horizontal Center Third" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -22193,6 +22204,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "撤銷"
+          }
+        }
+      }
+    },
+    "Window Direction/Name: Vertical Center Half" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Vertical Center Half"
           }
         }
       }

--- a/Loop/Utilities/RectangleTranslationLayer.swift
+++ b/Loop/Utilities/RectangleTranslationLayer.swift
@@ -27,6 +27,7 @@ enum RectangleTranslationLayer {
         "bottomHalf": .bottomHalf,
         "bottomRight": .bottomRightQuarter,
         "center": .center,
+        "centerHalf": .horizontalCenterHalf,
         "larger": .larger,
         "leftHalf": .leftHalf,
         "maximize": .maximize,

--- a/Loop/Window Management/WindowDirection+LocalizedString.swift
+++ b/Loop/Window Management/WindowDirection+LocalizedString.swift
@@ -49,6 +49,10 @@ extension WindowDirection {
             .init(localized: .init("Window Direction/Name: Bottom Half", defaultValue: "Bottom Half"))
         case .leftHalf:
             .init(localized: .init("Window Direction/Name: Left Half", defaultValue: "Left Half"))
+        case .horizontalCenterHalf:
+            .init(localized: .init("Window Direction/Name: Horizontal Center Half", defaultValue: "Horizontal Center Half"))
+        case .verticalCenterHalf:
+            .init(localized: .init("Window Direction/Name: Vertical Center Half", defaultValue: "Vertical Center Half"))
         case .topLeftQuarter:
             .init(localized: .init("Window Direction/Name: Top Left Quarter", defaultValue: "Top Left Quarter"))
         case .topRightQuarter:

--- a/Loop/Window Management/WindowDirection.swift
+++ b/Loop/Window Management/WindowDirection.swift
@@ -19,6 +19,7 @@ enum WindowDirection: String, CaseIterable, Identifiable, Codable {
 
     // Halves
     case topHalf = "TopHalf", rightHalf = "RightHalf", bottomHalf = "BottomHalf", leftHalf = "LeftHalf"
+    case horizontalCenterHalf = "HorizontalCenterHalf", verticalCenterHalf = "VerticalCenterHalf"
 
     // Quarters
     case topLeftQuarter = "TopLeftQuarter", topRightQuarter = "TopRightQuarter"
@@ -54,7 +55,7 @@ enum WindowDirection: String, CaseIterable, Identifiable, Codable {
 
     // These are used in the menubar resize submenu & keybind configuratio
     static var general: [WindowDirection] { [.fullscreen, .maximize, .almostMaximize, .center, .macOSCenter, .minimize, .hide] }
-    static var halves: [WindowDirection] { [.topHalf, .bottomHalf, .leftHalf, .rightHalf] }
+    static var halves: [WindowDirection] { [.topHalf, .bottomHalf, .leftHalf, .rightHalf, .horizontalCenterHalf, .verticalCenterHalf] }
     static var quarters: [WindowDirection] { [.topLeftQuarter, .topRightQuarter, .bottomLeftQuarter, .bottomRightQuarter] }
     static var horizontalThirds: [WindowDirection] { [.rightThird, .rightTwoThirds, .horizontalCenterThird, .leftTwoThirds, .leftThird] }
     static var verticalThirds: [WindowDirection] { [.topThird, .topTwoThirds, .verticalCenterThird, .bottomTwoThirds, .bottomThird] }
@@ -91,6 +92,8 @@ enum WindowDirection: String, CaseIterable, Identifiable, Codable {
         case .rightHalf: .init(x: 1.0 / 2.0, y: 0, width: 1.0 / 2.0, height: 1.0)
         case .bottomHalf: .init(x: 0, y: 1.0 / 2.0, width: 1.0, height: 1.0 / 2.0)
         case .leftHalf: .init(x: 0, y: 0, width: 1.0 / 2.0, height: 1.0)
+        case .horizontalCenterHalf: .init(x: 1.0 / 4.0, y: 0, width: 1.0 / 2.0, height: 1.0)
+        case .verticalCenterHalf: .init(x: 0, y: 1.0 / 4.0, width: 1.0, height: 1.0 / 2.0)
         // Quarters
         case .topLeftQuarter: .init(x: 0, y: 0, width: 1.0 / 2.0, height: 1.0 / 2.0)
         case .topRightQuarter: .init(x: 1.0 / 2.0, y: 0, width: 1.0 / 2.0, height: 1.0 / 2.0)

--- a/Loop/Window Management/WindowDirection.swift
+++ b/Loop/Window Management/WindowDirection.swift
@@ -55,7 +55,7 @@ enum WindowDirection: String, CaseIterable, Identifiable, Codable {
 
     // These are used in the menubar resize submenu & keybind configuratio
     static var general: [WindowDirection] { [.fullscreen, .maximize, .almostMaximize, .center, .macOSCenter, .minimize, .hide] }
-    static var halves: [WindowDirection] { [.topHalf, .bottomHalf, .leftHalf, .rightHalf, .horizontalCenterHalf, .verticalCenterHalf] }
+    static var halves: [WindowDirection] { [.topHalf, .verticalCenterHalf, .bottomHalf, .leftHalf, .horizontalCenterHalf, .rightHalf] }
     static var quarters: [WindowDirection] { [.topLeftQuarter, .topRightQuarter, .bottomLeftQuarter, .bottomRightQuarter] }
     static var horizontalThirds: [WindowDirection] { [.rightThird, .rightTwoThirds, .horizontalCenterThird, .leftTwoThirds, .leftThird] }
     static var verticalThirds: [WindowDirection] { [.topThird, .topTwoThirds, .verticalCenterThird, .bottomTwoThirds, .bottomThird] }


### PR DESCRIPTION
Add support for horizontal/vertical center half: 

<img width="307" alt="image" src="https://github.com/user-attachments/assets/0c1dc994-5def-411f-a032-2a0bad2a0ca8">


This matches center half in Recangle: 
 https://github.com/rxhanson/Rectangle/blob/309359b0e884580b45d64ea09def09e00e48b9e8/Rectangle/WindowAction.swift#L178

I have never contributed to any Swift/ObjC projects before. Please let me know if there are any things I missed.

