### PR TITLE
🐞 Fix cycle actions not working

### DIFF
--- a/Loop/Managers/LoopManager.swift
+++ b/Loop/Managers/LoopManager.swift
@@ -389,9 +389,9 @@ private extension LoopManager {
                 Notification.Name.updateUIDirection.post(userInfo: ["action": self.currentAction])
             }
 
-            if newAction.direction == .cycle {
+            if let parentCycleAction {
                 currentAction = newAction
-                changeAction(newAction, triggeredFromScreenChange: true)
+                changeAction(parentCycleAction, triggeredFromScreenChange: true)
             } else {
                 if let screenToResizeOn,
                    let window = targetWindow,


### PR DESCRIPTION
Not sure how I didn't catch this bug earlier :/

This fixes a bug where cycle keybinds stop advancing after switching screens. Please test before approving, since again, I find it really odd that this bug originally even made it to production.