### PR TITLE
✨ Respect the window tiling spacing set in `com.apple.WindowManager`

### DIFF
--- a/Loop/Managers/SystemWindowManager.swift
+++ b/Loop/Managers/SystemWindowManager.swift
@@ -110,24 +110,21 @@ class SystemWindowManager {
             windowManagerDefaults?.bool(forKey: "EnableTilingByEdgeDrag") ?? false
         }
 
+        static var enablePadding: Bool {
+            windowManagerDefaults?.bool(forKey: "EnableTiledWindowMargins") ?? false
+        }
+
         static var padding: CGFloat {
-            if windowManagerDefaults?.bool(forKey: "EnableTiledWindowMargins") == true {
-                if let customValue = windowManagerDefaults?.float(forKey: "TiledWindowSpacing") {
-                    CGFloat(customValue)
-                } else {
-                    8
-                }
-            } else {
-                0
-            }
+            windowManagerDefaults?.float(forKey: "TiledWindowSpacing") ?? 8
         }
 
         static func syncPadding() {
-            let newPadding = padding
+            let enablePadding = enablePadding
+            Defaults[.enablePadding] = enablePadding
 
-            Defaults[.enablePadding] = newPadding != 0
+            if enablePadding {
+                let newPadding = padding
 
-            if newPadding != 0 {
                 Defaults[.padding] = PaddingModel(
                     window: newPadding,
                     externalBar: 0,

--- a/Loop/Managers/SystemWindowManager.swift
+++ b/Loop/Managers/SystemWindowManager.swift
@@ -111,7 +111,15 @@ class SystemWindowManager {
         }
 
         static var padding: CGFloat {
-            windowManagerDefaults?.bool(forKey: "EnableTiledWindowMargins") ?? false ? 9 : 0
+            if windowManagerDefaults?.bool(forKey: "EnableTiledWindowMargins") == true {
+                if let customValue = windowManagerDefaults?.float(forKey: "TiledWindowSpacing") {
+                    CGFloat(customValue)
+                } else {
+                    8
+                }
+            } else {
+                0
+            }
         }
 
         static func syncPadding() {


### PR DESCRIPTION
In macOS Sequoia, you can tweak the spacing around windows. The key is `TiledWindowSpacing`.

I also bumped up the default from `8` to `9` (I think that's right based on my testing).

If you want to give it a shot, just run these commands.

```
defaults write com.apple.WindowManager EnableTiledWindowMargins -bool false; 
defaults write com.apple.WindowManager TiledWindowSpacing -float 16; 
defaults write com.apple.WindowManager EnableTiledWindowMargins -bool true;
```

**Note**
Toggling `EnableTiledWindowMargins` will move the windows you already have tiled. So, you don't need to restart the `WindowManager` to make the change.