### PR TITLE
💫 Improve window animations

### DIFF
--- a/Loop/Extensions/NSScreen+Extensions.swift
+++ b/Loop/Extensions/NSScreen+Extensions.swift
@@ -16,6 +16,17 @@ extension NSScreen {
         return deviceDescription[key] as? CGDirectDisplayID
     }
 
+    var displayMode: CGDisplayMode? {
+        guard
+            let id = displayID,
+            let displayMode = CGDisplayCopyDisplayMode(id)
+        else {
+            return nil
+        }
+
+        return displayMode
+    }
+
     static var screenWithMouse: NSScreen? {
         let mouseLocation = NSEvent.mouseLocation
         let screens = NSScreen.screens

--- a/Loop/Window Management/WindowTransformAnimation.swift
+++ b/Loop/Window Management/WindowTransformAnimation.swift
@@ -28,7 +28,7 @@ class WindowTransformAnimation: NSAnimation {
         self.bounds = bounds
         self.completionHandler = completionHandler
         super.init(duration: 0.3, animationCurve: .easeOut)
-        self.frameRate = Self.getCurrentRefreshRate() ?? 60.0
+        self.frameRate = Float(NSScreen.main?.displayMode?.refreshRate ?? 60.0)
         self.animationBlockingMode = .nonblocking
         self.lastWindowFrame = originalFrame
 
@@ -93,15 +93,5 @@ class WindowTransformAnimation: NSAnimation {
                 completionHandler()
             }
         }
-    }
-
-    static func getCurrentRefreshRate() -> Float? {
-        guard let activeScreen = NSScreen.main,
-              let screenNumber = activeScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
-              let displayMode = CGDisplayCopyDisplayMode(screenNumber) else {
-            return nil
-        }
-
-        return Float(displayMode.refreshRate)
     }
 }

--- a/Loop/Window Management/WindowTransformAnimation.swift
+++ b/Loop/Window Management/WindowTransformAnimation.swift
@@ -28,7 +28,7 @@ class WindowTransformAnimation: NSAnimation {
         self.bounds = bounds
         self.completionHandler = completionHandler
         super.init(duration: 0.3, animationCurve: .easeOut)
-        self.frameRate = 60.0
+        self.frameRate = Self.getCurrentRefreshRate() ?? 60.0
         self.animationBlockingMode = .nonblocking
         self.lastWindowFrame = originalFrame
 
@@ -57,10 +57,10 @@ class WindowTransformAnimation: NSAnimation {
             let value = CGFloat(1.0 - pow(1.0 - currentValue, 3))
 
             var newFrame = CGRect(
-                x: originalFrame.origin.x + value * (targetFrame.origin.x - originalFrame.origin.x),
-                y: originalFrame.origin.y + value * (targetFrame.origin.y - originalFrame.origin.y),
-                width: originalFrame.size.width + value * (targetFrame.size.width - originalFrame.size.width),
-                height: originalFrame.size.height + value * (targetFrame.size.height - originalFrame.size.height)
+                x: round(originalFrame.origin.x + value * (targetFrame.origin.x - originalFrame.origin.x)),
+                y: round(originalFrame.origin.y + value * (targetFrame.origin.y - originalFrame.origin.y)),
+                width: round(originalFrame.size.width + value * (targetFrame.size.width - originalFrame.size.width)),
+                height: round(originalFrame.size.height + value * (targetFrame.size.height - originalFrame.size.height))
             )
 
             // Keep the window inside the bounds
@@ -78,8 +78,14 @@ class WindowTransformAnimation: NSAnimation {
                 }
             }
 
-            window.position = newFrame.origin
-            window.size = newFrame.size
+            if lastWindowFrame.origin != newFrame.origin {
+                window.position = newFrame.origin
+            }
+
+            if lastWindowFrame.size != newFrame.size {
+                window.size = newFrame.size
+            }
+
             lastWindowFrame = window.frame
 
             if currentProgress >= 1.0 {
@@ -87,5 +93,15 @@ class WindowTransformAnimation: NSAnimation {
                 completionHandler()
             }
         }
+    }
+
+    static func getCurrentRefreshRate() -> Float? {
+        guard let activeScreen = NSScreen.main,
+              let screenNumber = activeScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+              let displayMode = CGDisplayCopyDisplayMode(screenNumber) else {
+            return nil
+        }
+
+        return Float(displayMode.refreshRate)
     }
 }


### PR DESCRIPTION
- Use the current refresh rate of the current display for `.frameRate`.
- Reduce the strain on the accessibility framework by never setting the same `position` or `size` twice. This should help reduce any redundant computation that might occur when the animation happens.
- Use `round` on `newFrame` so that we don't try and render frames with subpixel precision and make the compare statements work as intended.