### PR TITLE
🐞 Move window activation to after minimizing/hiding

### DIFF
--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -27,11 +27,6 @@ enum WindowEngine {
         let windowTitle = window.nsRunningApplication?.localizedName ?? window.title ?? "<unknown>"
         print("Resizing \(windowTitle) to \(action.direction) on \(screen.localizedName)")
 
-        // Note that this is only really useful when "Resize window under cursor" is enabled
-        if Defaults[.focusWindowOnResize] {
-            window.activate()
-        }
-
         // If the action is to hide or minimize, perform the action then return
         if action.direction == .hide {
             window.toggleHidden()
@@ -41,6 +36,11 @@ enum WindowEngine {
         if action.direction == .minimize {
             window.toggleMinimized()
             return
+        }
+
+        // Note that this is only really useful when "Resize window under cursor" is enabled
+        if Defaults[.focusWindowOnResize] {
+            window.activate()
         }
 
         if shouldRecord {


### PR DESCRIPTION
Shifts window activation to occur after the minimization or hiding operations. This prevents windows from being reactivated immediately following these actions.