### PR TITLE
🐞 Fix memory leak inside `CGEventMonitor`

### DIFF
--- a/Loop/Utilities/EventMonitor.swift
+++ b/Loop/Utilities/EventMonitor.swift
@@ -106,7 +106,7 @@ class CGEventMonitor: EventMonitor, Identifiable, Equatable {
                 let observer = Unmanaged<CGEventMonitor>.fromOpaque(refcon!).takeUnretainedValue()
                 return observer.handleEvent(event: event)
             },
-            userInfo: Unmanaged.passRetained(self).toOpaque()
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
         )
 
         if let eventTap {
@@ -130,7 +130,8 @@ class CGEventMonitor: EventMonitor, Identifiable, Equatable {
             self.runLoopSource = nil
         }
 
-        if eventTap != nil {
+        if let eventTap {
+            CFMachPortInvalidate(eventTap)
             self.eventTap = nil
         }
     }


### PR DESCRIPTION
This should help fix the issue where things slow down after a period of usage as it no longer keeps previous event monitors around after looping as it resigned its usage via `LoopManager.closeLoop`.

Before, event monitor was passed as retained to itself, which quickly created a retain cycle. Also, I added proper cleanup by invalidating the mach port when the event monitor is about to go out of scope.

- Pass user info as unretained into the `callback` to avoid the mach port never being released.
- Invalidate the event tap inside `deinit`.