### PR TITLE
✨ Sort keys on export

### DIFF
--- a/Loop/Utilities/Migrator.swift
+++ b/Loop/Utilities/Migrator.swift
@@ -186,7 +186,7 @@ private extension Migrator {
         let keybinds = SavedKeybindsFormat.generateFromDefaults()
 
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted]
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(keybinds)
 
         guard let json = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
Let's make exporting configurations more consistent by sorting the keys.

I did this for Keyboard Cowboy since I have my configuration checked into `git`. Without this, it was a real pain to compare different versions of the configuration. I hope this helps someone out!

This issue reminded me of the sort keys option: https://github.com/MrKai77/Loop/issues/645#issuecomment-2721747913