### PR TITLE
✨ Enable reverse cycling of window actions with Shift key

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		A8F0125B2AEDD7660017307F /* WindowAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F0125A2AEDD7660017307F /* WindowAction.swift */; };
 		A8F1E9662C253F5B00AAF871 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = A8F1E9652C253F5B00AAF871 /* Localizable.xcstrings */; };
 		A8F1E9692C253F8D00AAF871 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A8F1E9672C253F8D00AAF871 /* InfoPlist.strings */; };
+		F0642DAA2DD8C9F00049F167 /* CycleBackwardsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0642DA92DD8C9F00049F167 /* CycleBackwardsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -187,6 +188,7 @@
 		A8F1E9652C253F5B00AAF871 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		A8F1E9682C253F8D00AAF871 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A8F1E96B2C253FA200AAF871 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		F0642DA92DD8C9F00049F167 /* CycleBackwardsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleBackwardsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -381,6 +383,7 @@
 			isa = PBXGroup;
 			children = (
 				A8A1C5202BD4863B00515A14 /* KeybindsConfigurationView.swift */,
+				F0642DA92DD8C9F00049F167 /* CycleBackwardsView.swift */,
 				A8A583B92BE5A8D8005F4CB2 /* KeybindItemView.swift */,
 				A88E27AC2BDDE5300042CF04 /* CustomActionConfigurationView.swift */,
 				A8A583B72BE5A117005F4CB2 /* CycleActionConfigurationView.swift */,
@@ -642,6 +645,7 @@
 				A8A1C5212BD4863B00515A14 /* KeybindsConfigurationView.swift in Sources */,
 				A88E83C52B37B354009D332F /* CGEvent+Extensions.swift in Sources */,
 				4C93290A2D79928E00CE0B72 /* URLCommandHandler.swift in Sources */,
+				F0642DAA2DD8C9F00049F167 /* CycleBackwardsView.swift in Sources */,
 				A8E8903C2BA7AAFE006C5074 /* NSEvent+Extensions.swift in Sources */,
 				0A6DC3EB2BB869DE002AB05F /* WindowAction+Image.swift in Sources */,
 				A83E1C352ABFCA3200853FE9 /* WindowRecords.swift in Sources */,

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -55,6 +55,7 @@ extension Defaults.Keys {
     static let triggerDelay = Key<Double>("triggerDelay", default: 0, iCloud: true)
     static let doubleClickToTrigger = Key<Bool>("doubleClickToTrigger", default: false, iCloud: true)
     static let middleClickTriggersLoop = Key<Bool>("middleClickTriggersLoop", default: false, iCloud: true)
+    static let cycleBackwardsOnShiftPressed = Key<Bool>("cycleBackwardsOnShiftPressed", default: true, iCloud: true)
     static let keybinds = Key<[WindowAction]>(
         "keybinds",
         default: [

--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -3008,6 +3008,9 @@
         }
       }
     },
+    "Cycle backward with Shift" : {
+
+    },
     "Cycle Keybind" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3084,6 +3087,9 @@
           }
         }
       }
+    },
+    "Cycling actions backwards with the Shift key only works if Shift isn't part of your trigger key or keybind." : {
+
     },
     "Design" : {
       "extractionState" : "manual",

--- a/Loop/Luminare/Settings/Keybindings/CycleBackwardsView.swift
+++ b/Loop/Luminare/Settings/Keybindings/CycleBackwardsView.swift
@@ -1,0 +1,39 @@
+//
+//  CycleBackwardsView.swift
+//  Loop
+//
+//  Created by Guillaume Clédat on 17/05/2025.
+//
+
+import Foundation
+import Luminare
+import SwiftUI
+
+struct CycleBackwardsView: View {
+    var triggerKey: Set<CGKeyCode>
+
+    @Binding var isOn: Bool
+
+    var isShiftUsedByTriggerKey: Bool {
+        triggerKey.contains(.kVK_Shift)
+    }
+
+    var body: some View {
+        LuminareSection {
+            LuminareToggle("Cycle backward with Shift", info: cycleBackwardsInfoView, isOn: $isOn)
+                .onChange(of: isShiftUsedByTriggerKey) { newValue in
+                    if newValue {
+                        isOn = false
+                    }
+                }
+        }
+    }
+
+    private var cycleBackwardsInfoView: LuminareInfoView? {
+        guard isShiftUsedByTriggerKey else { return nil }
+        return LuminareInfoView(
+            "Cycling actions backwards with the Shift key only works if Shift isn't part of your trigger key or keybind.",
+            .orange
+        )
+    }
+}

--- a/Loop/Luminare/Settings/Keybindings/KeybindsConfigurationView.swift
+++ b/Loop/Luminare/Settings/Keybindings/KeybindsConfigurationView.swift
@@ -14,6 +14,10 @@ class KeybindsConfigurationModel: ObservableObject {
         didSet { Defaults[.triggerDelay] = triggerDelay }
     }
 
+    @Published var cycleBackwardsOnShiftPressed = Defaults[.cycleBackwardsOnShiftPressed] {
+        didSet { Defaults[.cycleBackwardsOnShiftPressed] = cycleBackwardsOnShiftPressed }
+    }
+
     @Published var doubleClickToTrigger = Defaults[.doubleClickToTrigger] {
         didSet { Defaults[.doubleClickToTrigger] = doubleClickToTrigger }
     }
@@ -32,11 +36,20 @@ struct KeybindsConfigurationView: View {
     @Default(.triggerKey) var triggerKey
     @Default(.keybinds) var keybinds
 
+    /// Is there at least one keybind action that is a cycle?
+    private var isCycleActionPresentInKeybinds: Bool {
+        keybinds.contains(where: { $0.cycle != nil })
+    }
+
     var body: some View {
         LuminareSection("Trigger Key", noBorder: true) {
             // TODO: Make long trigger keys fit in bounds
             TriggerKeycorder($triggerKey)
                 .environmentObject(model)
+        }
+
+        if isCycleActionPresentInKeybinds {
+            CycleBackwardsView(triggerKey: triggerKey, isOn: $model.cycleBackwardsOnShiftPressed)
         }
 
         LuminareSection("Settings") {

--- a/Loop/Managers/KeybindMonitor.swift
+++ b/Loop/Managers/KeybindMonitor.swift
@@ -100,6 +100,10 @@ class KeybindMonitor {
         flagsEventMonitor = nil
     }
 
+    func isShiftPressed() -> Bool {
+        pressedKeys.contains(.kVK_Shift)
+    }
+
     @discardableResult
     private func performKeybind(event: NSEvent) -> Bool {
         if event.type == .keyUp {

--- a/Loop/Managers/LoopManager.swift
+++ b/Loop/Managers/LoopManager.swift
@@ -328,9 +328,13 @@ private extension LoopManager {
         disableHapticFeedback: Bool = false,
         canAdvanceCycle: Bool = true
     ) {
-        // Only allow cycling backwards if either the action keybind or the trigger key includes the Shift key.
+        // Allow cycling backwards only if:
+        // - Shift is not part of the action's keybind
+        // - Shift is not part of the trigger key
+        // - The user has enabled the setting
         let allowReverseCycle = newAction.keybind.contains(.kVK_Shift) == false
             && Defaults[.triggerKey].contains(.kVK_Shift) == false
+            && Defaults[.cycleBackwardsOnShiftPressed]
 
         // This will allow us to compare different window actions without needing to consider different keybinds/custom names/ids.
         // This is useful when the radial menu and keybinds have the same set of cycle actions, so we don't need to worry about not having a keybind.

--- a/Loop/Managers/LoopManager.swift
+++ b/Loop/Managers/LoopManager.swift
@@ -328,6 +328,10 @@ private extension LoopManager {
         disableHapticFeedback: Bool = false,
         canAdvanceCycle: Bool = true
     ) {
+        // Only allow cycling backwards if either the action keybind or the trigger key includes the Shift key.
+        let allowReverseCycle = newAction.keybind.contains(.kVK_Shift) == false
+            && Defaults[.triggerKey].contains(.kVK_Shift) == false
+
         // This will allow us to compare different window actions without needing to consider different keybinds/custom names/ids.
         // This is useful when the radial menu and keybinds have the same set of cycle actions, so we don't need to worry about not having a keybind.
         var newAction = newAction.stripNonResizingProperties()
@@ -346,7 +350,7 @@ private extension LoopManager {
             // The ability to advance a cycle is only available when the action is triggered via a keybind or a left click on the mouse.
             // This will be set to false when the mouse is *moved* to prevent erratic behavior.
             if canAdvanceCycle {
-                newAction = getNextCycleAction(newAction)
+                newAction = getNextCycleAction(newAction, allowReverseCycle: allowReverseCycle)
             } else {
                 if let cycle = newAction.cycle, !cycle.contains(currentAction) {
                     newAction = cycle.first ?? .init(.noAction)
@@ -452,12 +456,13 @@ private extension LoopManager {
         }
     }
 
-    func getNextCycleAction(_ action: WindowAction) -> WindowAction {
+    func getNextCycleAction(_ action: WindowAction, allowReverseCycle: Bool) -> WindowAction {
         guard let currentCycle = action.cycle else {
             return action
         }
 
-        var nextIndex = 0
+        let shouldCycleBackwards = keybindMonitor.isShiftPressed() && allowReverseCycle
+        var currentIndex: Int? = nil
 
         // If the current action is noAction, we can preserve the index from the last action.
         // This would initially be done by reading the window's records, then would continue by finding the next index from the currentAction.
@@ -465,13 +470,24 @@ private extension LoopManager {
            !currentCycle.contains(currentAction),
            let window = targetWindow,
            let latestRecord = WindowRecords.getCurrentAction(for: window) {
-            nextIndex = (currentCycle.firstIndex(of: latestRecord) ?? -1) + 1
+            currentIndex = currentCycle.firstIndex(of: latestRecord)
         } else {
-            nextIndex = (currentCycle.firstIndex(of: currentAction) ?? -1) + 1
+            currentIndex = currentCycle.firstIndex(of: currentAction)
         }
 
+        guard var nextIndex = currentIndex else {
+            return currentCycle[0]
+        }
+
+        nextIndex += shouldCycleBackwards ? -1 : 1
+
+        // Wrap around the cycle index if we've reached the end or gone before the start.
         if nextIndex >= currentCycle.count {
             nextIndex = 0
+        }
+
+        if nextIndex < 0 {
+            nextIndex = currentCycle.count - 1
         }
 
         return currentCycle[nextIndex]


### PR DESCRIPTION
This is an initial implementation for [#696](https://github.com/MrKai77/Loop/issues/696), adding support for cycling backwards through actions when the Shift key is pressed.

With this code, backward cycling is enabled for all Cycle actions **if** the Shift key is pressed and neither the trigger key nor the keybind already includes Shift.

To support this behavior, I introduced an `isShiftPressed()` method in `KeybindMonitor`. It's a bit of a rough solution, so if you have a cleaner approach in mind, I'm happy to revise it.

Also, we should discuss the feature's scope. It might make sense to add a global toggle to enable/disable backward cycling *or* add per-cycle configuration of this behavior

Feedback is welcome—especially on implementation design and configurability.