### PR TITLE
🐞 Match window frame before initializing `Window`

### DIFF
--- a/Loop/Window Management/Window.swift
+++ b/Loop/Window Management/Window.swift
@@ -79,43 +79,39 @@ class Window {
     convenience init(windowInfo: [String: AnyObject]) throws {
         // First, check if we can initialize a window simply based on its PID.
         guard
-            let alpha = windowInfo[kCGWindowAlpha as String] as? Double, alpha > 0.01, // Don't allow invisible windows
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double, alpha > 0.01, // Ignore invisible windows
             let pid = windowInfo[kCGWindowOwnerPID as String] as? pid_t
         else {
             throw WindowError.invalidWindow
         }
 
         let element = AXUIElementCreateApplication(pid)
-        guard
-            let windows: [AXUIElement] = try element.getValue(.windows),
-            !windows.isEmpty
+        guard let windows: [AXUIElement] = try element.getValue(.windows),
+              !windows.isEmpty
         else {
             throw WindowError.invalidWindow
         }
 
         // If there’s only one window, use that as there's no need to grab its frame
-        if windows.count == 1, let window = windows.first {
-            try self.init(element: window)
+        if windows.count == 1 {
+            try self.init(element: windows[0])
             return
         }
 
-        // Now that we know that we can't *only* match by PID, fetch the window's frame, and match on bounds.
-        guard
-            let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: CGFloat],
-            let frame = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
-        else {
-            throw WindowError.invalidWindow
+        // Try to match against the frame when there are multiple windows
+        if let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: CGFloat],
+           let frame = CGRect(dictionaryRepresentation: boundsDict as CFDictionary),
+           let match = try windows.first(where: { window in
+               let position: CGPoint? = try window.getValue(.position)
+               let size: CGSize? = try window.getValue(.size)
+               return position == frame.origin && size == frame.size
+           }) {
+            try self.init(element: match)
+            return
         }
 
-        guard let match = try windows.first(where: { window in
-            let position: CGPoint? = try window.getValue(.position)
-            let size: CGSize? = try window.getValue(.size)
-            return position == frame.origin && size == frame.size
-        }) else {
-            throw WindowError.invalidWindow
-        }
-
-        try self.init(element: match)
+        // Fallback! initialize from the first available window
+        try self.init(element: windows[0])
     }
 
     deinit {

--- a/Loop/Window Management/Window.swift
+++ b/Loop/Window Management/Window.swift
@@ -74,6 +74,44 @@ class Window {
         try self.init(element: window)
     }
 
+    /// Initialize a window from an entry in a dictionary returned by `CGWindowListCopyWindowInfo`.
+    /// - Parameter windowInfo: The dictionary containing information about the window.
+    convenience init(windowInfo: [String: AnyObject]) throws {
+        guard
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double, alpha > 0.01, // Don't allow invisible windows
+            let pid = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+            let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: CGFloat],
+            let frame = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+        else {
+            throw WindowError.invalidWindow
+        }
+
+        let element = AXUIElementCreateApplication(pid)
+        guard
+            let windows: [AXUIElement] = try element.getValue(.windows),
+            !windows.isEmpty
+        else {
+            throw WindowError.invalidWindow
+        }
+
+        // If there’s only one window, use that as there's no need to grab its frame
+        if windows.count == 1, let window = windows.first {
+            try self.init(element: window)
+            return
+        }
+
+        // Otherwise, match on bounds
+        guard let match = try windows.first(where: { window in
+            let position: CGPoint? = try window.getValue(.position)
+            let size: CGSize? = try window.getValue(.size)
+            return position == frame.origin && size == frame.size
+        }) else {
+            throw WindowError.invalidWindow
+        }
+
+        try self.init(element: match)
+    }
+
     deinit {
         if let observer = self.observer {
             observer.stop()

--- a/Loop/Window Management/Window.swift
+++ b/Loop/Window Management/Window.swift
@@ -77,11 +77,10 @@ class Window {
     /// Initialize a window from an entry in a dictionary returned by `CGWindowListCopyWindowInfo`.
     /// - Parameter windowInfo: The dictionary containing information about the window.
     convenience init(windowInfo: [String: AnyObject]) throws {
+        // First, check if we can initialize a window simply based on its PID.
         guard
             let alpha = windowInfo[kCGWindowAlpha as String] as? Double, alpha > 0.01, // Don't allow invisible windows
-            let pid = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
-            let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: CGFloat],
-            let frame = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+            let pid = windowInfo[kCGWindowOwnerPID as String] as? pid_t
         else {
             throw WindowError.invalidWindow
         }
@@ -100,7 +99,14 @@ class Window {
             return
         }
 
-        // Otherwise, match on bounds
+        // Now that we know that we can't *only* match by PID, fetch the window's frame, and match on bounds.
+        guard
+            let boundsDict = windowInfo[kCGWindowBounds as String] as? [String: CGFloat],
+            let frame = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
+        else {
+            throw WindowError.invalidWindow
+        }
+
         guard let match = try windows.first(where: { window in
             let position: CGPoint? = try window.getValue(.position)
             let size: CGSize? = try window.getValue(.size)

--- a/Loop/Window Management/WindowEngine.swift
+++ b/Loop/Window Management/WindowEngine.swift
@@ -164,7 +164,7 @@ enum WindowEngine {
     /// Get the frontmost Window
     /// - Returns: Window?
     static func getFrontmostWindow() throws -> Window? {
-        guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.isActive }) else {
+        guard let app = NSWorkspace.shared.frontmostApplication else {
             return nil
         }
         return try Window(pid: app.processIdentifier)
@@ -199,16 +199,10 @@ enum WindowEngine {
         }
 
         var windowList: [Window] = []
-        for window in list {
-            guard
-                let alpha = window[kCGWindowAlpha as String] as? Double, alpha > 0.01,
-                let pid = window[kCGWindowOwnerPID as String] as? Int32,
-                let window = try? Window(pid: pid)
-            else {
-                continue
+        for windowInfo in list {
+            if let window = try? Window(windowInfo: windowInfo) {
+                windowList.append(window)
             }
-
-            windowList.append(window)
         }
 
         return windowList


### PR DESCRIPTION
By comparing the frame, we can correctly handle multiple windows from the same PID. This is important for actions like “Minimize Others,” where different windows share an owner PID, and each Window instance must represent the actual window rather than just its PID.