### PR TITLE
🐞 Adjust size increment slider step value in AdvancedConfigurationView

### DIFF
--- a/Loop/Settings Window/Loop/AdvancedConfiguration.swift
+++ b/Loop/Settings Window/Loop/AdvancedConfiguration.swift
@@ -202,7 +202,7 @@ struct AdvancedConfigurationView: View {
                 "Size increment",
                 value: $sizeIncrement.doubleBinding,
                 in: 5...50,
-                step: 4.5,
+                step: 5,
                 format: .number.precision(.fractionLength(0...0)),
                 clampsUpper: false,
                 suffix: Text("px")


### PR DESCRIPTION
## Problem

The Size Increment setting had a critical usability issue where typing values in the number field would behave unexpectedly:

- Typing `2` would immediately jump to `5` (the minimum value)
- Then typing `0` would result in `50` instead of the intended `20`
- This made it extremely difficult to set the default value of `20px`

As described in issue #836, the only workaround was to:
1. Type `2` (which becomes `5`)
2. Backspace to delete the `5`
3. Type `2` again (which finally works)
4. Type `0` to get `20`

## Root Cause

The `LuminareSlider` for Size Increment was configured with a `step` parameter of `4.5`, which created the following valid values:

5, 10, 15, 20, 25, 30, 35, 40, 45, 50


Now:
- The default value of `20px` is included in the valid range
- Typing `20` in the number field works correctly on the first try
- All increment values are whole numbers

## Changes

- `Loop/Settings Window/Loop/AdvancedConfiguration.swift`: Changed `step: 4.5` to `step: 5`

Closes #836