### PR TITLE
🐞 Fix screen handling in WindowDragManager and PreviewController for accurate mouse position tracking

### DIFF
--- a/Loop/Core/WindowDragManager.swift
+++ b/Loop/Core/WindowDragManager.swift
@@ -74,7 +74,11 @@ class WindowDragManager {
     }
 
     private func setCurrentDraggingWindow() {
-        let mousePosition = NSEvent.mouseLocation.flipY(screen: NSScreen.screens[0])
+        guard let currentScreen = NSScreen.screenWithMouse else {
+            return
+        }
+        
+        let mousePosition = NSEvent.mouseLocation.flipY(screen: currentScreen)
 
         do {
             guard
@@ -136,9 +140,8 @@ class WindowDragManager {
             return
         }
 
-        let mainScreen = NSScreen.screens[0]
-        let mousePosition = NSEvent.mouseLocation.flipY(screen: mainScreen)
-        let screenFrame = screen.frame.flipY(screen: mainScreen)
+        let mousePosition = NSEvent.mouseLocation.flipY(screen: screen)
+        let screenFrame = screen.frame.flipY(screen: screen)
 
         previewController.setScreen(to: screen)
 

--- a/Loop/Window Action Indicators/Preview Window/PreviewController.swift
+++ b/Loop/Window Action Indicators/Preview Window/PreviewController.swift
@@ -103,7 +103,7 @@ final class PreviewController {
             screen: screen,
             isPreview: true
         )
-        .flipY(maxY: NSScreen.screens[0].frame.maxY)
+        .flipY(maxY: screen.frame.maxY)
 
         // What is the screen's frame
         print("Target frame: \(targetWindowFrame)")

--- a/Loop/Window Management/Window Manipulation/WindowEngine.swift
+++ b/Loop/Window Management/Window Manipulation/WindowEngine.swift
@@ -95,7 +95,7 @@ enum WindowEngine {
 
         // If the window is one of Loop's windows, resize it using the actual NSWindow, preventing crashes
         if window.nsRunningApplication?.bundleIdentifier == Bundle.main.bundleIdentifier {
-            resizeOwnWindow(targetFrame: targetFrame)
+            resizeOwnWindow(targetFrame: targetFrame, screen: screen)
         }
 
         let usePadding = PaddingSettings.enablePadding &&
@@ -195,7 +195,7 @@ enum WindowEngine {
         return true
     }
 
-    private static func resizeOwnWindow(targetFrame: CGRect) {
+    private static func resizeOwnWindow(targetFrame: CGRect, screen: NSScreen) {
         guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: {
             $0.level.rawValue <= NSWindow.Level.floating.rawValue
         }) else {
@@ -205,7 +205,7 @@ enum WindowEngine {
 
         NSAnimationContext.runAnimationGroup { context in
             context.timingFunction = CAMediaTimingFunction(controlPoints: 0.33, 1, 0.68, 1)
-            window.animator().setFrame(targetFrame.flipY(screen: .screens[0]), display: false)
+            window.animator().setFrame(targetFrame.flipY(screen: screen), display: false)
         }
     }
 


### PR DESCRIPTION
## Problem

- Windows would unexpectedly jump from the external display to the main display
- The jump occurred while dragging windows within the same secondary screen (not between displays)
- Window snapping and preview indicators would appear on the wrong screen

## Root Cause
The bug was caused by hardcoded references to NSScreen.screens[0] in coordinate conversion code. In macOS, screens[0] always refers to the primary display, regardless of where the mouse or window is located.

The problem occurred in the flipY() coordinate conversion function, which translates between:

- macOS coordinate system: Origin (0,0) at bottom-left, Y increases upward
- AppKit coordinate system: Origin (0,0) at top-left, Y increases downward
When dragging on a secondary display, the code was using the main screen's coordinate space for conversions instead of the actual screen's coordinate space, causing incorrect frame calculations that resulted in windows jumping to the main display.

## Solution
Replaced all hardcoded NSScreen.screens[0] references with the appropriate screen context:

- Use NSScreen.screenWithMouse to get the screen where the mouse is currently located
- Use the already-determined screen parameter instead of assuming the main screen
- Pass the correct screen parameter through function calls
This ensures coordinate conversions always use the correct screen's frame as reference.

## Expected Behavior After Fix
- Windows stay on the secondary display when dragging
- Window snapping works correctly on all displays
- Preview indicators appear on the correct screen
- Coordinate calculations are accurate across all display configurations
- Loop's settings window can be properly positioned on any display

Closes #835