### PR TITLE
🐞 Do not swallow mid-click down event

### DIFF
--- a/Loop/Core/Triggers/MiddleClickObserver.swift
+++ b/Loop/Core/Triggers/MiddleClickObserver.swift
@@ -66,9 +66,9 @@ final class MiddleClickObserver: LoopTrigger {
                 openCallback()
             }
 
-            return nil
-
+            return Unmanaged.passUnretained(event)
         } else {
+            triggerDelayTimer?.cancel()
             closeCallback()
             return Unmanaged.passUnretained(event)
         }


### PR DESCRIPTION
## Problem
The current implementation of handling mid-click is to completely ignore the mid-click down event. This is undesired in many cases. For example, mid-click (up+down) is often used in a browser to quickly close a tab. Loop currently completely swallows such mouse events so that mid-click won't work correctly in these cases.

## Modifications
The patch here is simple. 
1. Return the mid-click down event as usual.
2. Cancel the trigger delay timer if there is any. In this case (when the delay timer is not nil), it means the user releases the mouse mid-button before the delay, so we should cancel the timer.