### PR TITLE
✨ Add support for side-independent trigger keys

### DIFF
--- a/Loop/Core/Triggers/KeybindObserver.swift
+++ b/Loop/Core/Triggers/KeybindObserver.swift
@@ -30,6 +30,11 @@ final class KeybindObserver {
 
     private var useTriggerDelay: Bool { Defaults[.triggerDelay] > 0.1 }
     private var doubleClickToTrigger: Bool { Defaults[.doubleClickToTrigger] }
+    private var sideDependentTriggerKey: Bool { Defaults[.sideDependentTriggerKey] }
+    private var triggerKey: Set<CGKeyCode> {
+        sideDependentTriggerKey ? Defaults[.triggerKey] : Defaults[.triggerKey].baseModifiers
+    }
+
     private lazy var triggerDelayTimer = TriggerDelayTimer(openCallback: openCallback)
     private lazy var doubleClickTimer = DoubleClickTimer { [weak self] action in
         guard let self else { return }
@@ -131,9 +136,8 @@ final class KeybindObserver {
     ///   - flags: modifier flags associated with this event.
     /// - Returns: whether this event was processed by Loop.
     private func performKeybind(type: CGEventType, isARepeat: Bool, flags: CGEventFlags) -> Bool {
-        let triggerKey: Set<CGKeyCode> = Defaults[.triggerKey]
-
-        let allPressedKeys: Set<CGKeyCode> = pressedKeys.union(flags.keyCodes)
+        let flagKeys = sideDependentTriggerKey ? flags.keyCodes : flags.keyCodes.baseModifiers
+        let allPressedKeys: Set<CGKeyCode> = pressedKeys.union(flagKeys)
         let actionKeys: Set<CGKeyCode> = allPressedKeys.subtracting(triggerKey)
         let containsTrigger = allPressedKeys.isSuperset(of: triggerKey)
 

--- a/Loop/Core/Triggers/KeybindObserver.swift
+++ b/Loop/Core/Triggers/KeybindObserver.swift
@@ -170,7 +170,9 @@ final class KeybindObserver {
                         openLoop(startingAction: action, overrideExistingTriggerDelayTimerAction: true)
                     }
                     return true
-                } else {
+                }
+
+                if allPressedKeys == triggerKey {
                     openLoop(startingAction: nil, overrideExistingTriggerDelayTimerAction: !isARepeat)
                     return false
                 }

--- a/Loop/Core/Triggers/KeybindObserver.swift
+++ b/Loop/Core/Triggers/KeybindObserver.swift
@@ -172,6 +172,7 @@ final class KeybindObserver {
                     return true
                 }
 
+                // Only trigger Loop without an action if the only pressed keys perfectly matches the trigger key.
                 if allPressedKeys == triggerKey {
                     openLoop(startingAction: nil, overrideExistingTriggerDelayTimerAction: !isARepeat)
                     return false

--- a/Loop/Core/Triggers/MiddleClickObserver.swift
+++ b/Loop/Core/Triggers/MiddleClickObserver.swift
@@ -21,6 +21,7 @@ final class MiddleClickObserver {
     private var middleClickTriggersLoop: Bool { Defaults[.middleClickTriggersLoop] }
     private var useTriggerDelay: Bool { Defaults[.enableTriggerDelayOnMiddleClick] && Defaults[.triggerDelay] > 0.1 }
     private var doubleClickToTrigger: Bool { Defaults[.doubleClickToTrigger] }
+
     private lazy var triggerDelayTimer = TriggerDelayTimer(openCallback: openCallback)
     private lazy var doubleClickTimer = DoubleClickTimer { [weak self] action in
         guard let self else { return }

--- a/Loop/Extensions/CGKeyCode+Extensions.swift
+++ b/Loop/Extensions/CGKeyCode+Extensions.swift
@@ -277,7 +277,7 @@ extension CGKeyCode {
     ]
 
     // Make sure to use baseModifier before using this!
-    private static let modifierToImage: [CGKeyCode: String] = [
+    private static let modifierToSystemImage: [CGKeyCode: String] = [
         .kVK_Function: "globe",
         .kVK_Shift: "shift",
         .kVK_Command: "command",
@@ -286,7 +286,7 @@ extension CGKeyCode {
     ]
 
     var modifierSystemImage: String? {
-        if let systemName = CGKeyCode.modifierToImage[baseModifier] {
+        if let systemName = CGKeyCode.modifierToSystemImage[baseModifier] {
             systemName
         } else {
             nil

--- a/Loop/Extensions/CGKeyCode+Extensions.swift
+++ b/Loop/Extensions/CGKeyCode+Extensions.swift
@@ -367,3 +367,10 @@ extension CGKeyCode {
         }
     }
 }
+
+extension Set<CGKeyCode> {
+    /// Maps all modifier keys to their base variant. Used on trigger key when the user has disabled side-dependent trigger keys.
+    var baseModifiers: Set<CGKeyCode> {
+        Set(map(\.baseModifier))
+    }
+}

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -61,6 +61,7 @@ extension Defaults.Keys {
 
     // Keybinds
     static let triggerKey = Key<Set<CGKeyCode>>("trigger", default: [.kVK_Function], iCloud: true)
+    static let sideDependentTriggerKey = Key<Bool>("sideDependentTriggerKey", default: true, iCloud: true)
     static let triggerDelay = Key<Double>("triggerDelay", default: 0, iCloud: true)
     static let doubleClickToTrigger = Key<Bool>("doubleClickToTrigger", default: false, iCloud: true)
     static let middleClickTriggersLoop = Key<Bool>("middleClickTriggersLoop", default: false, iCloud: true)

--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -3043,6 +3043,9 @@
         }
       }
     },
+    "Cycles" : {
+
+    },
     "Design" : {
       "localizations" : {
         "ar" : {
@@ -7461,6 +7464,7 @@
     },
     "Left %@" : {
       "comment" : "Trigger Key: Left side",
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -16746,6 +16750,7 @@
     },
     "Right %@" : {
       "comment" : "Trigger Key: Right side",
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -19946,6 +19951,9 @@
           }
         }
       }
+    },
+    "Treat left and right keys differently" : {
+
     },
     "Trigger delay" : {
       "localizations" : {

--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -3044,7 +3044,7 @@
       }
     },
     "Cycles" : {
-
+      "comment" : "Section header for cycle-related options in the “Keybinds” tab"
     },
     "Design" : {
       "localizations" : {
@@ -19953,7 +19953,7 @@
       }
     },
     "Treat left and right keys differently" : {
-
+      "comment" : "Setting label in the “Keybinds” tab for enabling separate behavior for left and right keys."
     },
     "Trigger delay" : {
       "localizations" : {

--- a/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/TriggerKeycorder.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/TriggerKeycorder.swift
@@ -26,7 +26,8 @@ struct TriggerKeycorder: View {
     @State private var tooManyKeysPopup: Bool = false
 
     private var sortedKeys: [CGKeyCode] {
-        selectionKey.sorted()
+        let selectionKey: Set<CGKeyCode> = sideDependentTriggerKey ? selectionKey : selectionKey.baseModifiers
+        return selectionKey.sorted()
     }
 
     init(_ key: Binding<Set<CGKeyCode>>) {

--- a/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/TriggerKeycorder.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/TriggerKeycorder.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 struct TriggerKeycorder: View {
     @EnvironmentObject private var model: KeybindsConfigurationModel
+    @Environment(\.luminareAnimation) private var luminareAnimation
+    @Default(.sideDependentTriggerKey) private var sideDependentTriggerKey
 
     let keyLimit: Int = 5
 
@@ -22,6 +24,10 @@ struct TriggerKeycorder: View {
     @State private var isHovering: Bool = false
     @State private var isActive: Bool = false
     @State private var tooManyKeysPopup: Bool = false
+
+    private var sortedKeys: [CGKeyCode] {
+        selectionKey.sorted()
+    }
 
     init(_ key: Binding<Set<CGKeyCode>>) {
         self._validCurrentKey = key
@@ -40,16 +46,10 @@ struct TriggerKeycorder: View {
                         .fixedSize(horizontal: true, vertical: false)
                 } else {
                     HStack(spacing: 12) {
-                        ForEach(selectionKey.sorted(), id: \.self) { key in
-                            let keyText: LocalizedStringKey = key.isModifierOnRightSide ?
-                                "Right \(Image(systemName: key.modifierSystemImage ?? "exclamationmark.circle.fill"))" :
-                                "Left \(Image(systemName: key.modifierSystemImage ?? "exclamationmark.circle.fill"))"
+                        ForEach(sortedKeys, id: \.self) { key in
+                            TriggerKeycorderKeyView(key: key)
 
-                            Text(keyText)
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .fixedSize(horizontal: true, vertical: false)
-
-                            if key != selectionKey.sorted().last {
+                            if key != sortedKeys.last {
                                 Divider()
                                     .padding(1)
                             }
@@ -59,6 +59,7 @@ struct TriggerKeycorder: View {
                 }
             }
             .modifier(ShakeEffect(shakes: shouldShake ? 2 : 0))
+            .animation(luminareAnimation, value: sideDependentTriggerKey)
             .animation(Animation.default, value: shouldShake)
             .popover(isPresented: $tooManyKeysPopup, arrowEdge: .bottom) {
                 Text("You can only use up to \(keyLimit) keys in your trigger key.")
@@ -153,5 +154,24 @@ struct TriggerKeycorder: View {
         eventMonitor = nil
 
         LoopManager.shared.keybindObserver.start()
+    }
+}
+
+struct TriggerKeycorderKeyView: View {
+    @Default(.sideDependentTriggerKey) private var sideDependentTriggerKey
+    private static let defaultIconName = "exclamationmark.circle.fill"
+    let key: CGKeyCode
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if sideDependentTriggerKey {
+                Text(key.isModifierOnRightSide ? "Right" : "Left")
+                    .transition(.move(edge: .leading).combined(with: .opacity))
+            }
+
+            Text("\(Image(systemName: key.modifierSystemImage ?? Self.defaultIconName))")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .fixedSize(horizontal: true, vertical: false)
     }
 }

--- a/Loop/Settings Window/Settings/Keybindings/KeybindsConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybindings/KeybindsConfigurationView.swift
@@ -20,6 +20,7 @@ struct KeybindsConfigurationView: View {
     @StateObject private var model = KeybindsConfigurationModel()
 
     @Default(.triggerKey) private var triggerKey
+    @Default(.sideDependentTriggerKey) private var sideDependentTriggerKey
     @Default(.triggerDelay) private var triggerDelay
     @Default(.cycleModeRestartEnabled) private var cycleModeRestartEnabled
     @Default(.cycleBackwardsOnShiftPressed) private var cycleBackwardsOnShiftPressed
@@ -81,37 +82,45 @@ struct KeybindsConfigurationView: View {
     }
 
     private var settingsSection: some View {
-        LuminareSection("Settings") {
-            LuminareSlider(
-                "Trigger delay",
-                value: $triggerDelay,
-                in: 0...1,
-                step: 0.1,
-                format: .number.precision(.fractionLength(1...1)),
-                clampsUpper: false,
-                suffix: .init(.init(localized: "Measurement unit: seconds", defaultValue: "s"))
-            )
+        Group {
+            LuminareSection("Settings") {
+                LuminareToggle("Treat left and right keys differently", isOn: $sideDependentTriggerKey)
 
-            LuminareToggle("Double-click to trigger", isOn: $doubleClickToTrigger)
-            LuminareToggle("Middle-click to trigger", isOn: $middleClickTriggersLoop)
+                LuminareSlider(
+                    "Trigger delay",
+                    value: $triggerDelay,
+                    in: 0...1,
+                    step: 0.1,
+                    format: .number.precision(.fractionLength(1...1)),
+                    clampsUpper: false,
+                    suffix: .init(.init(localized: "Measurement unit: seconds", defaultValue: "s"))
+                )
 
-            if showMiddleClickTriggerDelayOption {
-                LuminareToggle("Apply trigger delay on middle-click", isOn: $enableTriggerDelayOnMiddleClick)
-            }
+                LuminareToggle("Double-click to trigger", isOn: $doubleClickToTrigger)
+                LuminareToggle("Middle-click to trigger", isOn: $middleClickTriggersLoop)
 
-            if showCycleRestartOption {
-                LuminareToggle(isOn: $cycleModeRestartEnabled) {
-                    Text("Always start cycles from first item")
-                        .padding(.trailing, 4)
-                        .luminarePopover(attachedTo: .topTrailing) {
-                            Text("By default, Loop resumes cycles from where you last left off in each window.")
-                                .padding(6)
-                        }
+                if showMiddleClickTriggerDelayOption {
+                    LuminareToggle("Apply trigger delay on middle-click", isOn: $enableTriggerDelayOnMiddleClick)
                 }
             }
 
-            if showCycleBackwardsOption {
-                LuminareToggle("Cycle backward with Shift", isOn: $cycleBackwardsOnShiftPressed)
+            if showCycleRestartOption || showCycleBackwardsOption {
+                LuminareSection("Cycles") {
+                    if showCycleRestartOption {
+                        LuminareToggle(isOn: $cycleModeRestartEnabled) {
+                            Text("Always start cycles from first item")
+                                .padding(.trailing, 4)
+                                .luminarePopover(attachedTo: .topTrailing) {
+                                    Text("By default, Loop resumes cycles from where you last left off in each window.")
+                                        .padding(6)
+                                }
+                        }
+                    }
+
+                    if showCycleBackwardsOption {
+                        LuminareToggle("Cycle backward with Shift", isOn: $cycleBackwardsOnShiftPressed)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This toggle lets users disable Loop’s default behavior of distinguishing between left and right modifier keys.

For example, if the trigger key is left command, turning off “Treat left and right keys differently” will make Loop respond to both the left and right command keys.