### PR TITLE
🐞 Fix recording of arrow key keybindings

### DIFF
--- a/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/Keycorder.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/Keycorder.swift
@@ -133,8 +133,12 @@ struct Keycorder: View {
         let currentKeys = selectionKeybind + [event.keyCode]
             .map { $0.baseKey(flags: event.modifierFlags) }
 
-        let flags = CGEventFlags(cocoaFlags: event.modifierFlags)
+        var flags = CGEventFlags(cocoaFlags: event.modifierFlags)
 
+        if event.keyCode.isFnSpecialKey {
+            flags.remove(.maskSecondaryFn)
+        }
+        
         // Filter out trigger keys from flags
         let validModifiers = flags.keyCodes.filter {
             !Defaults[.triggerKey]

--- a/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/Keycorder.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Keybind Recorder/Keycorder.swift
@@ -138,7 +138,7 @@ struct Keycorder: View {
         if event.keyCode.isFnSpecialKey {
             flags.remove(.maskSecondaryFn)
         }
-        
+
         // Filter out trigger keys from flags
         let validModifiers = flags.keyCodes.filter {
             !Defaults[.triggerKey]


### PR DESCRIPTION
Fixes the inability to record an arrow keybinding without also including the globe/fn key by removing the function key from the captured modifier keys if the key is a "special" key.