### PR TITLE
🐞 Fix window animation lag during screen transitions

### DIFF
--- a/Loop/Window Management/Window Manipulation/WindowTransformAnimation.swift
+++ b/Loop/Window Management/Window Manipulation/WindowTransformAnimation.swift
@@ -86,7 +86,7 @@ final class WindowTransformAnimation: NSAnimation {
                 window.size = newFrame.size
             }
 
-            lastWindowFrame = window.frame
+            lastWindowFrame = newFrame
 
             if currentProgress >= 1.0 {
                 WindowTransformAnimation.currentAnimations[window.cgWindowID] = nil


### PR DESCRIPTION
## Description

Fixes a race condition in `WindowTransformAnimation` that caused visible stuttering and incorrect window positioning during animations, particularly when moving windows between screens with different resolutions.

## Problem

The animation loop was updating `lastWindowFrame` using `window.frame`, which internally calls the Accessibility API to get the current window position and size. However, the Accessibility API is **asynchronous** - when we set `window.position` or `window.size`, the actual window update happens later in the target application.

This caused a timing issue:
1. Frame N: Set `window.position = newFrame.origin` (async request sent)
2. Frame N: Read `lastWindowFrame = window.frame` (returns **stale** value from Frame N-1)
3. Frame N+1: Bounds checking uses incorrect `lastWindowFrame` values
4. Result: Window jumps/stutters or is positioned incorrectly

## Solution

Changed line 89 in `WindowTransformAnimation.swift`:

```swift
// Before (buggy):
lastWindowFrame = window.frame  // Async API call, returns stale data

// After (fixed):
lastWindowFrame = newFrame      // Synchronous local variable, always current
```

Using the locally calculated `newFrame` ensures the bounds checking logic always uses the intended frame values, eliminating the race condition.