### PR TITLE
🐞 Put `determineDraggedWindowTask = nil` inside `defer` block

### DIFF
--- a/Loop/Core/Triggers/KeybindObserver.swift
+++ b/Loop/Core/Triggers/KeybindObserver.swift
@@ -177,7 +177,7 @@ final class KeybindObserver {
                     if !isARepeat || action.willManipulateExistingWindowFrame {
                         openLoop(startingAction: action, overrideExistingTriggerDelayTimerAction: true)
                     }
-                    
+
                     /// Only consume the event if the last command actually opened Loop.
                     /// The main reason Loop *wouldn't* open after an `openLoop` call would be because the user has enabled a trigger delay.
                     return checkIfLoopOpen() ? .consume : .opening

--- a/Loop/Core/WindowDragManager.swift
+++ b/Loop/Core/WindowDragManager.swift
@@ -115,9 +115,15 @@ final class WindowDragManager {
 
     @MainActor
     private func setCurrentDraggingWindow() {
-        if determineDraggedWindowTask != nil { return }
+        guard determineDraggedWindowTask == nil else {
+            return
+        }
 
         determineDraggedWindowTask = Task {
+            defer {
+                determineDraggedWindowTask = nil
+            }
+
             guard
                 let draggingWindow = try? WindowUtility.windowAtPosition(currentMousePosition),
                 !draggingWindow.isAppExcluded
@@ -129,8 +135,6 @@ final class WindowDragManager {
             initialWindowFrame = draggingWindow.frame
 
             logger.info("Determined window being dragged: \(draggingWindow.debugDescription)")
-
-            determineDraggedWindowTask = nil
         }
     }
 


### PR DESCRIPTION
Otherwise, `determineDraggedWindowTask` was never reset to `nil` in an excluded app or when the accessibility API call failed, preventing it from being able to determine any future dragged windows.