### PR TITLE
✨ Increase maximum corner radius value in preview configuration

### DIFF
--- a/Loop/Settings Window/Theming/PreviewConfiguration.swift
+++ b/Loop/Settings Window/Theming/PreviewConfiguration.swift
@@ -56,7 +56,7 @@ struct PreviewConfigurationView: View {
             LuminareSlider(
                 "Corner radius",
                 value: $previewCornerRadius.doubleBinding,
-                in: 0...20,
+                in: 0...25,
                 format: .number.precision(.fractionLength(0...0)),
                 clampsUpper: false,
                 clampsLower: false,


### PR DESCRIPTION
macOS 26 Tahoe default values:
  - 16pt (Title Bar only)
  - 20pt (Compact Toolbar)
  - 24pt (Toolbar)

#887