### PR TITLE
✨ Lightweight `IconView`

### DIFF
--- a/Loop/Settings Window/Settings/Keybindings/Item View/DirectionPickerView.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Item View/DirectionPickerView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DirectionPickerView: View {
-    @Environment(\.luminarePopupPadding) private var luminarePopupPadding
+    private let padding: CGFloat = 12
 
     @State private var searchText = ""
     @State private var searchResults: [WindowDirection] = []
@@ -60,18 +60,18 @@ struct DirectionPickerView: View {
     var body: some View {
         VStack(spacing: 0) {
             CustomTextField($searchText)
-                .padding(luminarePopupPadding)
+                .padding(padding)
 
             Divider()
 
             PickerList(
                 $direction,
                 $searchResults,
+                padding,
                 Self.sections + [moreSection]
             ) { item in
                 HStack(spacing: 8) {
                     IconView(action: .init(item))
-                        .equatable()
 
                     Text(item.name)
                 }

--- a/Loop/Settings Window/Settings/Keybindings/Item View/KeybindItemView.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Item View/KeybindItemView.swift
@@ -144,7 +144,6 @@ struct KeybindItemView: View {
         } label: {
             HStack(spacing: 8) {
                 IconView(action: action)
-                    .equatable()
 
                 if let info = action.direction.infoText {
                     Text(action.getName())

--- a/Loop/Settings Window/Settings/Keybindings/Item View/PickerList.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Item View/PickerList.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 struct PickerList<Content, V>: View where Content: View, V: Hashable, V: Identifiable {
     @EnvironmentObject private var popover: LuminarePopupPanel
-    @Environment(\.luminarePopupPadding) private var luminarePopupPadding
 
     private let logger = Logger(category: "PickerView")
 
@@ -22,28 +21,31 @@ struct PickerList<Content, V>: View where Content: View, V: Hashable, V: Identif
     @State private var eventMonitor: LocalEventMonitor?
     @State private var isInitialRender = true
 
+    private let padding: CGFloat
     private let sections: [PickerSection<V>]
     private let content: (V) -> Content
 
     init(
         _ selection: Binding<V>,
         _ searchResults: Binding<[V]>,
+        _ padding: CGFloat,
         _ sections: [PickerSection<V>],
         @ViewBuilder content: @escaping (V) -> Content
     ) {
         self._selection = selection
         self._searchResults = searchResults
         self.sections = sections
+        self.padding = padding
         self.content = content
     }
 
     var body: some View {
         ScrollViewReader { reader in
             ScrollView(showsIndicators: false) {
-                LazyVStack(spacing: luminarePopupPadding) {
+                LazyVStack(spacing: padding) {
                     contentStack(reader: reader)
                 }
-                .padding(luminarePopupPadding / 2)
+                .padding(padding / 2)
             }
         }
     }
@@ -80,15 +82,16 @@ struct PickerList<Content, V>: View where Content: View, V: Hashable, V: Identif
                         selection: $selection,
                         arrowSelection: arrowSelection,
                         item: item,
-                        content: content
+                        content: content,
+                        padding: padding / 2
                     )
                     .id(item)
                 }
             } header: {
                 Text(section.title)
                     .foregroundStyle(.secondary)
-                    .padding(.leading, luminarePopupPadding / 2)
-                    .padding(.top, luminarePopupPadding / 2)
+                    .padding(.leading, padding / 2)
+                    .padding(.top, padding / 2)
             }
         }
     }
@@ -99,7 +102,8 @@ struct PickerList<Content, V>: View where Content: View, V: Hashable, V: Identif
                 selection: $selection,
                 arrowSelection: arrowSelection,
                 item: item,
-                content: content
+                content: content,
+                padding: padding / 2
             )
             .id(item)
         }
@@ -154,7 +158,6 @@ struct PickerList<Content, V>: View where Content: View, V: Hashable, V: Identif
 
 struct PopoverPickerItem<Content, V>: View where Content: View, V: Hashable {
     @EnvironmentObject private var popover: LuminarePopupPanel
-    @Environment(\.luminarePopupPadding) private var luminarePopupPadding
     @Environment(\.luminareAnimationFast) private var animationFast
 
     @State private var isHovering = false
@@ -162,6 +165,7 @@ struct PopoverPickerItem<Content, V>: View where Content: View, V: Hashable {
     let arrowSelection: V?
     let item: V
     let content: (V) -> Content
+    let padding: CGFloat
 
     private var isActive: Bool {
         selection == item
@@ -177,7 +181,7 @@ struct PopoverPickerItem<Content, V>: View where Content: View, V: Hashable {
             popover.resignKey()
         } label: {
             content(item)
-                .padding(luminarePopupPadding / 2)
+                .padding(padding)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .buttonStyle(

--- a/Loop/Settings Window/Settings/Keybindings/Modal Views/CustomActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Modal Views/CustomActionConfigurationView.swift
@@ -222,7 +222,6 @@ struct CustomActionConfigurationView: View {
                     columns: 3
                 ) { anchor in
                     IconView(action: anchor.iconAction)
-                        .equatable()
                 }
                 .luminarePickerRoundedCorner(bottom: .always)
 

--- a/Loop/Settings Window/Settings/Keybindings/Modal Views/StashActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybindings/Modal Views/StashActionConfigurationView.swift
@@ -203,7 +203,6 @@ struct StashActionConfigurationView: View {
                     columns: 2
                 ) { anchor in
                     IconView(action: anchor.iconAction)
-                        .equatable()
                 }
                 .luminarePickerRoundedCorner(top: .always, bottom: .always)
             } else {

--- a/Loop/Window Action Indicators/Radial Menu/RadialMenuView.swift
+++ b/Loop/Window Action Indicators/Radial Menu/RadialMenuView.swift
@@ -133,15 +133,12 @@ struct RadialMenuView: View {
         }
     }
 
+    @ViewBuilder
     private func overlayImage() -> some View {
-        Group {
-            if viewModel.invalidWindowSelected {
-                Image(systemName: "exclamationmark.triangle")
-            } else if let image = viewModel.radialMenuImage {
-                image
-            }
+        if let image = viewModel.radialMenuImage {
+            image
+                .foregroundStyle(accentColorController.color1)
+                .font(.system(size: 20, weight: .bold))
         }
-        .foregroundStyle(accentColorController.color1)
-        .font(.system(size: 20, weight: .bold))
     }
 }

--- a/Loop/Window Action Indicators/Radial Menu/RadialMenuViewModel.swift
+++ b/Loop/Window Action Indicators/Radial Menu/RadialMenuViewModel.swift
@@ -34,10 +34,6 @@ final class RadialMenuViewModel: ObservableObject {
         recomputeAngle()
     }
 
-    var invalidWindowSelected: Bool {
-        window == nil && !previewMode
-    }
-
     var shouldFillRadialMenu: Bool {
         currentAction?.direction.shouldFillRadialMenu ?? false
     }
@@ -51,7 +47,14 @@ final class RadialMenuViewModel: ObservableObject {
     }
 
     var radialMenuImage: Image? {
-        currentAction?.icon
+        if window == nil, !previewMode {
+            return Image(systemName: "exclamationmark.triangle")
+        } else if let image = currentAction?.image {
+            let image = image.withSymbolConfiguration(.init(pointSize: 20, weight: .bold)) ?? image
+            return Image(nsImage: image)
+        } else {
+            return nil
+        }
     }
 
     func setWindow(to newWindow: Window) {

--- a/Loop/Window Management/Window Action/WindowAction+Image.swift
+++ b/Loop/Window Management/Window Action/WindowAction+Image.swift
@@ -9,62 +9,62 @@ import Luminare
 import SwiftUI
 
 extension WindowAction {
-    var icon: Image? {
+    var image: NSImage? {
         switch direction {
         case .undo:
-            Image(systemName: "arrow.uturn.backward")
+            NSImage(systemSymbolName: "arrow.uturn.backward", accessibilityDescription: nil)
         case .initialFrame:
-            Image(systemName: "backward.end.alt.fill")
+            NSImage(systemSymbolName: "backward.end.alt.fill", accessibilityDescription: nil)
         case .hide:
-            Image(systemName: "eye.slash.fill")
+            NSImage(systemSymbolName: "eye.slash.fill", accessibilityDescription: nil)
         case .minimize:
-            Image(systemName: "arrow.down.right.and.arrow.up.left")
+            NSImage(systemSymbolName: "arrow.down.right.and.arrow.up.left", accessibilityDescription: nil)
         case .minimizeOthers:
-            Image(systemName: "arrow.down.right.and.arrow.up.left")
+            NSImage(systemSymbolName: "arrow.down.right.and.arrow.up.left", accessibilityDescription: nil)
         case .maximizeHeight:
-            Image(systemName: "arrow.up.and.down")
+            NSImage(systemSymbolName: "arrow.up.and.down", accessibilityDescription: nil)
         case .maximizeWidth:
-            Image(systemName: "arrow.left.and.right")
+            NSImage(systemSymbolName: "arrow.left.and.right", accessibilityDescription: nil)
         case .nextScreen:
-            Image(systemName: "forward.fill")
+            NSImage(systemSymbolName: "forward.fill", accessibilityDescription: nil)
         case .previousScreen:
-            Image(systemName: "backward.fill")
+            NSImage(systemSymbolName: "backward.fill", accessibilityDescription: nil)
         case .leftScreen:
-            Image(systemName: "arrow.left.to.line")
+            NSImage(systemSymbolName: "arrow.left.to.line", accessibilityDescription: nil)
         case .rightScreen:
-            Image(systemName: "arrow.right.to.line")
+            NSImage(systemSymbolName: "arrow.right.to.line", accessibilityDescription: nil)
         case .topScreen:
-            Image(systemName: "arrow.up.to.line")
+            NSImage(systemSymbolName: "arrow.up.to.line", accessibilityDescription: nil)
         case .bottomScreen:
-            Image(systemName: "arrow.down.to.line")
+            NSImage(systemSymbolName: "arrow.down.to.line", accessibilityDescription: nil)
         case .larger:
-            Image(systemName: "arrow.up.left.and.arrow.down.right")
+            NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: nil)
         case .smaller:
-            Image(systemName: "arrow.down.right.and.arrow.up.left")
+            NSImage(systemSymbolName: "arrow.down.right.and.arrow.up.left", accessibilityDescription: nil)
         case .shrinkTop, .growBottom, .moveDown:
-            Image(systemName: "arrow.down")
+            NSImage(systemSymbolName: "arrow.down", accessibilityDescription: nil)
         case .shrinkBottom, .growTop, .moveUp:
-            Image(systemName: "arrow.up")
+            NSImage(systemSymbolName: "arrow.up", accessibilityDescription: nil)
         case .shrinkRight, .growLeft, .moveLeft:
-            Image(systemName: "arrow.left")
+            NSImage(systemSymbolName: "arrow.left", accessibilityDescription: nil)
         case .shrinkLeft, .growRight, .moveRight:
-            Image(systemName: "arrow.right")
+            NSImage(systemSymbolName: "arrow.right", accessibilityDescription: nil)
         case .shrinkHorizontal:
-            Image(systemName: "arrow.right.and.line.vertical.and.arrow.left")
+            NSImage(systemSymbolName: "arrow.right.and.line.vertical.and.arrow.left", accessibilityDescription: nil)
         case .growHorizontal:
-            Image(systemName: "arrow.left.and.line.vertical.and.arrow.right")
+            NSImage(systemSymbolName: "arrow.left.and.line.vertical.and.arrow.right", accessibilityDescription: nil)
         case .shrinkVertical:
-            Image(systemName: "arrow.down.and.line.horizontal.and.arrow.up")
+            NSImage(systemSymbolName: "arrow.down.and.line.horizontal.and.arrow.up", accessibilityDescription: nil)
         case .growVertical:
-            Image(systemName: "arrow.up.and.line.horizontal.and.arrow.down")
+            NSImage(systemSymbolName: "arrow.up.and.line.horizontal.and.arrow.down", accessibilityDescription: nil)
         case .focusLeft:
-            Image(systemName: "chevron.left")
+            NSImage(systemSymbolName: "chevron.left", accessibilityDescription: nil)
         case .focusRight:
-            Image(systemName: "chevron.right")
+            NSImage(systemSymbolName: "chevron.right", accessibilityDescription: nil)
         case .focusUp:
-            Image(systemName: "chevron.up")
+            NSImage(systemSymbolName: "chevron.up", accessibilityDescription: nil)
         case .focusDown:
-            Image(systemName: "chevron.down")
+            NSImage(systemSymbolName: "chevron.down", accessibilityDescription: nil)
         default:
             nil
         }
@@ -77,78 +77,257 @@ extension WindowAction {
 /// - the `icon` property is used for common actions like hide, minimize, growing and shrinking, which cannot be easily represented by a frame.
 /// - a simple frame preview is used for more general actions such as right half, maximize, and center, as well as custom keybinds when available.
 /// - finally, a default icon is used for cycle actions and actions without a specific icon or frame representation as backup (just in case, they shouldn't be needed in practice).
-///
-/// It is also important to note that this view conforms to `Equatable` to prevent accidental re-renders when used in lists or other dynamic views.
-/// Please ensure that the `.equatable()` modifier is applied when using this view in such contexts.
-struct IconView: View, Equatable {
-    @Environment(\.luminareAnimationFast) private var luminareAnimationFast
-
+struct IconView: NSViewRepresentable {
     private let action: WindowAction
-    private let size = CGSize(width: 14, height: 10)
-    private let inset: CGFloat = 2
-    private let outerCornerRadius: CGFloat = 3
-    private var frame: CGRect {
-        action.getFrame(
-            window: nil,
-            bounds: .init(origin: .zero, size: size),
-            disablePadding: true
+    private let size: CGSize
+
+    init(
+        action: WindowAction,
+        size: CGSize = .init(
+            width: 18,
+            height: 14
         )
-    }
-
-    /// Creates an icon view for a given window action.
-    /// - Parameter action: The window action to represent.
-    init(action: WindowAction) {
+    ) {
         self.action = action
+        self.size = size
     }
 
-    var body: some View {
+    func makeNSView(context _: Context) -> IconRenderView {
+        let view = IconRenderView()
+
         if action.direction == .cycle, let first = action.cycle?.first {
-            IconView(action: first)
-                .id(first.id)
-                .animation(luminareAnimationFast, value: first)
+            view.setAction(to: first, animated: false)
         } else {
-            Group {
-                if let icon = action.icon {
-                    icon
-                        .font(.system(size: 8))
-                        .fontWeight(.bold)
-                        .frame(width: size.width, height: size.height, alignment: .center)
-                } else if frame.size.area != 0 {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: outerCornerRadius - inset)
-                            .frame(
-                                width: frame.width,
-                                height: frame.height
-                            )
-                            .offset(
-                                x: frame.origin.x,
-                                y: frame.origin.y
-                            )
-                    }
-                    .frame(width: size.width, height: size.height, alignment: .topLeading)
-                } else if action.direction == .cycle {
-                    Image(.repeat4)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: size.width, height: size.height, alignment: .center)
-                } else {
-                    Image(.ruler)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: size.width, height: size.height, alignment: .center)
-                }
-            }
-            .clipShape(.rect(cornerRadius: outerCornerRadius - inset))
-            .background {
-                RoundedRectangle(cornerRadius: outerCornerRadius)
-                    .stroke(lineWidth: 1)
-                    .padding(-inset)
-            }
-            .padding(.horizontal, 4)
+            view.setAction(to: action, animated: false)
+        }
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.widthAnchor.constraint(equalToConstant: size.width),
+            view.heightAnchor.constraint(equalToConstant: size.height)
+        ])
+
+        return view
+    }
+
+    func updateNSView(_ view: IconRenderView, context _: Context) {
+        if action.direction == .cycle, let first = action.cycle?.first {
+            view.setAction(to: first, animated: true)
+        } else {
+            view.setAction(to: action, animated: true)
+        }
+    }
+}
+
+final class IconRenderView: NSView {
+    private var currentAction: WindowAction = .init(.noAction)
+
+    private let strokeLayer = CAShapeLayer()
+    private let fillLayer = CAShapeLayer()
+    private let imageLayer = CALayer()
+
+    private let cornerRadius: CGFloat = 3
+    private let inset: CGFloat = 2
+    private let strokeWidth: CGFloat = 1.5
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    func setAction(
+        to action: WindowAction,
+        animated: Bool,
+        duration: CFTimeInterval = 0.1
+    ) {
+        guard !action.isSameManipulation(as: currentAction) else { return }
+        currentAction = action
+        updatePath(animated: animated, duration: duration)
+    }
+
+    override func layout() {
+        super.layout()
+        updatePath(animated: false)
+    }
+
+    // MARK: - Private
+
+    private func setup() {
+        wantsLayer = true
+        clipsToBounds = true
+
+        layer?.addSublayer(strokeLayer)
+        layer?.addSublayer(fillLayer)
+        layer?.addSublayer(imageLayer)
+
+        strokeLayer.fillColor = NSColor.clear.cgColor
+        strokeLayer.strokeColor = NSColor.textColor.cgColor
+        strokeLayer.lineWidth = 1
+        strokeLayer.cornerCurve = .continuous
+
+        fillLayer.fillColor = NSColor.textColor.cgColor
+        fillLayer.cornerCurve = .continuous
+
+        imageLayer.contentsGravity = .resizeAspect
+    }
+
+    private func processStrokeLayer(strokeInset: CGFloat) {
+        let strokeRect = bounds.insetBy(dx: strokeInset, dy: strokeInset)
+        let strokePath = CGPath(
+            roundedRect: strokeRect,
+            cornerWidth: cornerRadius,
+            cornerHeight: cornerRadius,
+            transform: nil
+        )
+        strokeLayer.path = strokePath
+    }
+
+    enum DisplayMode {
+        case frame(CGRect)
+        case image(NSImage)
+    }
+
+    private func determineDisplayMode(fillBounds: CGRect) -> DisplayMode? {
+        if let image = currentAction.image {
+            return .image(image)
+        }
+
+        let frame = currentAction.getFrame(
+            window: nil,
+            bounds: .init(origin: .zero, size: .init(width: 1, height: 1)),
+            disablePadding: true
+        ).flipY(maxY: 1)
+
+        if frame.size.area != 0 {
+            let fillFrame = CGRect(
+                x: fillBounds.minX + fillBounds.width * frame.minX,
+                y: fillBounds.minY + fillBounds.height * frame.minY,
+                width: fillBounds.width * frame.width,
+                height: fillBounds.height * frame.height
+            )
+
+            return .frame(fillFrame)
+        }
+
+        // And if all else fails...
+
+        if currentAction.direction == .custom {
+            return .image(NSImage(resource: .ruler))
+        }
+
+        if currentAction.direction == .cycle {
+            return .image(NSImage(resource: .repeat4))
+        }
+
+        return nil
+    }
+
+    private func updatePath(
+        animated: Bool = true,
+        duration: CFTimeInterval = 0.1
+    ) {
+        strokeLayer.frame = bounds
+        fillLayer.frame = bounds
+
+        let strokeInset = strokeWidth / 2
+        processStrokeLayer(strokeInset: strokeInset)
+
+        let fillInset = strokeInset + inset
+        let fillBounds = bounds.insetBy(dx: fillInset, dy: fillInset)
+
+        guard let displayMode = determineDisplayMode(fillBounds: fillBounds) else {
+            fillLayer.opacity = 0
+            imageLayer.opacity = 0
+            return
+        }
+
+        switch displayMode {
+        case let .frame(fillRect):
+            let newFillPath = CGPath(
+                roundedRect: fillRect,
+                cornerWidth: cornerRadius - inset,
+                cornerHeight: cornerRadius - inset,
+                transform: nil
+            )
+            animatePathChange(layer: fillLayer, to: newFillPath, animated: animated, duration: duration)
+            animateAlpha(layer: fillLayer, to: 1, animated: animated, duration: duration)
+            animateAlpha(layer: imageLayer, to: 0, animated: animated, duration: duration)
+
+        case let .image(image):
+            imageLayer.contents = processImage(image)
+            imageLayer.frame = getImageBounds()
+
+            animateAlpha(layer: fillLayer, to: 0, animated: animated, duration: duration)
+            animateAlpha(layer: imageLayer, to: 1, animated: animated, duration: duration)
         }
     }
 
-    static func == (lhs: IconView, rhs: IconView) -> Bool {
-        lhs.action == rhs.action
+    private func animatePathChange(
+        layer: CAShapeLayer,
+        to new: CGPath?,
+        animated: Bool,
+        duration: CFTimeInterval
+    ) {
+        guard let new else { return }
+
+        if animated {
+            let animation = CABasicAnimation(keyPath: "path")
+            animation.fromValue = layer.path
+            animation.toValue = new
+            animation.duration = duration
+            animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            layer.add(animation, forKey: "path")
+        }
+
+        layer.path = new
+    }
+
+    private func animateAlpha(
+        layer: CALayer,
+        to target: Float,
+        animated: Bool,
+        duration: CFTimeInterval
+    ) {
+        if animated {
+            let anim = CABasicAnimation(keyPath: "opacity")
+            anim.fromValue = layer.opacity
+            anim.toValue = target
+            anim.duration = duration
+            layer.add(anim, forKey: "opacity")
+        }
+
+        layer.opacity = target
+    }
+
+    private func processImage(_ image: NSImage, color: NSColor = .textColor) -> NSImage? {
+        let image = image.withSymbolConfiguration(.init(pointSize: 12, weight: .bold)) ?? image
+
+        if image.isTemplate {
+            return NSImage(size: image.size, flipped: false) { destinationRect in
+                image.draw(in: destinationRect)
+                color.setFill()
+                destinationRect.fill(using: .sourceIn)
+                return true
+            }
+        } else {
+            return image
+        }
+    }
+
+    private func getImageBounds() -> NSRect {
+        let insetBounds = bounds.insetBy(dx: strokeWidth, dy: strokeWidth)
+        let side = min(insetBounds.width, insetBounds.height)
+        let squareRect = CGRect(
+            x: insetBounds.midX - side / 2,
+            y: insetBounds.midY - side / 2,
+            width: side,
+            height: side
+        )
+        return squareRect
     }
 }

--- a/Loop/Window Management/Window Action/WindowAction+Image.swift
+++ b/Loop/Window Management/Window Action/WindowAction+Image.swift
@@ -121,6 +121,7 @@ struct IconView: NSViewRepresentable {
 
 final class IconRenderView: NSView {
     private var currentAction: WindowAction = .init(.noAction)
+    private var lastDisplayMode: DisplayMode?
 
     private let strokeLayer = CAShapeLayer()
     private let fillLayer = CAShapeLayer()
@@ -129,6 +130,11 @@ final class IconRenderView: NSView {
     private let cornerRadius: CGFloat = 3
     private let inset: CGFloat = 2
     private let strokeWidth: CGFloat = 1.5
+
+    enum DisplayMode {
+        case frame(CGRect)
+        case image(NSImage)
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -155,6 +161,11 @@ final class IconRenderView: NSView {
         updatePath(animated: false)
     }
 
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateColors()
+    }
+
     // MARK: - Private
 
     private func setup() {
@@ -165,15 +176,64 @@ final class IconRenderView: NSView {
         layer?.addSublayer(fillLayer)
         layer?.addSublayer(imageLayer)
 
-        strokeLayer.fillColor = NSColor.clear.cgColor
-        strokeLayer.strokeColor = NSColor.textColor.cgColor
         strokeLayer.lineWidth = 1
         strokeLayer.cornerCurve = .continuous
-
-        fillLayer.fillColor = NSColor.textColor.cgColor
         fillLayer.cornerCurve = .continuous
-
         imageLayer.contentsGravity = .resizeAspect
+
+        updateColors()
+    }
+
+    private func updateColors() {
+        strokeLayer.fillColor = .clear
+        strokeLayer.strokeColor = NSColor.textColor.cgColor
+        fillLayer.fillColor = NSColor.textColor.cgColor
+
+        if case let .image(image) = lastDisplayMode {
+            imageLayer.contents = processImage(image, color: .textColor)
+        }
+    }
+
+    private func updatePath(
+        animated: Bool = true,
+        duration: CFTimeInterval = 0.1
+    ) {
+        strokeLayer.frame = bounds
+        fillLayer.frame = bounds
+
+        let strokeInset = strokeWidth / 2
+        processStrokeLayer(strokeInset: strokeInset)
+
+        let fillInset = strokeInset + inset
+        let fillBounds = bounds.insetBy(dx: fillInset, dy: fillInset)
+
+        guard let displayMode = determineDisplayMode(fillBounds: fillBounds) else {
+            fillLayer.opacity = 0
+            imageLayer.opacity = 0
+            return
+        }
+
+        switch displayMode {
+        case let .frame(fillRect):
+            let newFillPath = CGPath(
+                roundedRect: fillRect,
+                cornerWidth: cornerRadius - inset,
+                cornerHeight: cornerRadius - inset,
+                transform: nil
+            )
+            animatePathChange(layer: fillLayer, to: newFillPath, animated: animated, duration: duration)
+            animateAlpha(layer: fillLayer, to: 1, animated: animated, duration: duration)
+            animateAlpha(layer: imageLayer, to: 0, animated: animated, duration: duration)
+
+        case let .image(image):
+            imageLayer.contents = processImage(image, color: .textColor)
+            imageLayer.frame = getImageBounds()
+
+            animateAlpha(layer: fillLayer, to: 0, animated: animated, duration: duration)
+            animateAlpha(layer: imageLayer, to: 1, animated: animated, duration: duration)
+        }
+
+        lastDisplayMode = displayMode
     }
 
     private func processStrokeLayer(strokeInset: CGFloat) {
@@ -185,11 +245,6 @@ final class IconRenderView: NSView {
             transform: nil
         )
         strokeLayer.path = strokePath
-    }
-
-    enum DisplayMode {
-        case frame(CGRect)
-        case image(NSImage)
     }
 
     private func determineDisplayMode(fillBounds: CGRect) -> DisplayMode? {
@@ -225,46 +280,6 @@ final class IconRenderView: NSView {
         }
 
         return nil
-    }
-
-    private func updatePath(
-        animated: Bool = true,
-        duration: CFTimeInterval = 0.1
-    ) {
-        strokeLayer.frame = bounds
-        fillLayer.frame = bounds
-
-        let strokeInset = strokeWidth / 2
-        processStrokeLayer(strokeInset: strokeInset)
-
-        let fillInset = strokeInset + inset
-        let fillBounds = bounds.insetBy(dx: fillInset, dy: fillInset)
-
-        guard let displayMode = determineDisplayMode(fillBounds: fillBounds) else {
-            fillLayer.opacity = 0
-            imageLayer.opacity = 0
-            return
-        }
-
-        switch displayMode {
-        case let .frame(fillRect):
-            let newFillPath = CGPath(
-                roundedRect: fillRect,
-                cornerWidth: cornerRadius - inset,
-                cornerHeight: cornerRadius - inset,
-                transform: nil
-            )
-            animatePathChange(layer: fillLayer, to: newFillPath, animated: animated, duration: duration)
-            animateAlpha(layer: fillLayer, to: 1, animated: animated, duration: duration)
-            animateAlpha(layer: imageLayer, to: 0, animated: animated, duration: duration)
-
-        case let .image(image):
-            imageLayer.contents = processImage(image)
-            imageLayer.frame = getImageBounds()
-
-            animateAlpha(layer: fillLayer, to: 0, animated: animated, duration: duration)
-            animateAlpha(layer: imageLayer, to: 1, animated: animated, duration: duration)
-        }
     }
 
     private func animatePathChange(
@@ -305,18 +320,19 @@ final class IconRenderView: NSView {
     }
 
     private func processImage(_ image: NSImage, color: NSColor = .textColor) -> NSImage? {
+        guard image.isTemplate else { return image }
         let image = image.withSymbolConfiguration(.init(pointSize: 12, weight: .bold)) ?? image
 
-        if image.isTemplate {
-            return NSImage(size: image.size, flipped: false) { destinationRect in
-                image.draw(in: destinationRect)
-                color.setFill()
-                destinationRect.fill(using: .sourceIn)
-                return true
-            }
-        } else {
-            return image
-        }
+        let sizedImage = NSImage(size: image.size)
+        sizedImage.lockFocus()
+        defer { sizedImage.unlockFocus() }
+
+        image.draw(at: .zero, from: .zero, operation: .sourceOver, fraction: 1)
+        color.setFill()
+        let rect = NSRect(origin: .zero, size: image.size)
+        rect.fill(using: .sourceIn)
+
+        return sizedImage
     }
 
     private func getImageBounds() -> NSRect {

--- a/Loop/Window Management/Window Action/WindowAction+Image.swift
+++ b/Loop/Window Management/Window Action/WindowAction+Image.swift
@@ -148,17 +148,16 @@ final class IconRenderView: NSView {
 
     func setAction(
         to action: WindowAction,
-        animated: Bool,
-        duration: CFTimeInterval = 0.1
+        animated: Bool
     ) {
         guard !action.isSameManipulation(as: currentAction) else { return }
         currentAction = action
-        updatePath(animated: animated, duration: duration)
+        updatePath(duration: animated ? 0.2 : 0.0)
     }
 
     override func layout() {
         super.layout()
-        updatePath(animated: false)
+        updatePath(duration: 0.0)
     }
 
     override func viewDidChangeEffectiveAppearance() {
@@ -194,15 +193,12 @@ final class IconRenderView: NSView {
         }
     }
 
-    private func updatePath(
-        animated: Bool = true,
-        duration: CFTimeInterval = 0.1
-    ) {
+    private func updatePath(duration: CFTimeInterval) {
         strokeLayer.frame = bounds
         fillLayer.frame = bounds
 
         let strokeInset = strokeWidth / 2
-        processStrokeLayer(strokeInset: strokeInset)
+        processStrokeLayerPath(strokeInset: strokeInset)
 
         let fillInset = strokeInset + inset
         let fillBounds = bounds.insetBy(dx: fillInset, dy: fillInset)
@@ -215,28 +211,26 @@ final class IconRenderView: NSView {
 
         switch displayMode {
         case let .frame(fillRect):
-            let newFillPath = CGPath(
+            let newPath = CGPath(
                 roundedRect: fillRect,
                 cornerWidth: cornerRadius - inset,
                 cornerHeight: cornerRadius - inset,
                 transform: nil
             )
-            animatePathChange(layer: fillLayer, to: newFillPath, animated: animated, duration: duration)
-            animateAlpha(layer: fillLayer, to: 1, animated: animated, duration: duration)
-            animateAlpha(layer: imageLayer, to: 0, animated: animated, duration: duration)
-
+            animateAlpha(layer: fillLayer, to: 1, duration: duration)
+            animateAlpha(layer: imageLayer, to: 0, duration: duration)
+            animatePath(layer: fillLayer, to: newPath, duration: duration)
         case let .image(image):
             imageLayer.contents = processImage(image, color: .textColor)
             imageLayer.frame = getImageBounds()
-
-            animateAlpha(layer: fillLayer, to: 0, animated: animated, duration: duration)
-            animateAlpha(layer: imageLayer, to: 1, animated: animated, duration: duration)
+            animateAlpha(layer: fillLayer, to: 0, duration: duration)
+            animateAlpha(layer: imageLayer, to: 1, duration: duration)
         }
 
         lastDisplayMode = displayMode
     }
 
-    private func processStrokeLayer(strokeInset: CGFloat) {
+    private func processStrokeLayerPath(strokeInset: CGFloat) {
         let strokeRect = bounds.insetBy(dx: strokeInset, dy: strokeInset)
         let strokePath = CGPath(
             roundedRect: strokeRect,
@@ -282,44 +276,41 @@ final class IconRenderView: NSView {
         return nil
     }
 
-    private func animatePathChange(
+    private func animatePath(
         layer: CAShapeLayer,
-        to new: CGPath?,
-        animated: Bool,
+        to target: CGPath,
         duration: CFTimeInterval
     ) {
-        guard let new else { return }
-
-        if animated {
+        if duration > 0 {
             let animation = CABasicAnimation(keyPath: "path")
             animation.fromValue = layer.path
-            animation.toValue = new
+            animation.toValue = target
             animation.duration = duration
             animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
             layer.add(animation, forKey: "path")
         }
 
-        layer.path = new
+        layer.path = target
     }
 
     private func animateAlpha(
         layer: CALayer,
         to target: Float,
-        animated: Bool,
         duration: CFTimeInterval
     ) {
-        if animated {
-            let anim = CABasicAnimation(keyPath: "opacity")
-            anim.fromValue = layer.opacity
-            anim.toValue = target
-            anim.duration = duration
-            layer.add(anim, forKey: "opacity")
+        if duration > 0 {
+            let animation = CABasicAnimation(keyPath: "opacity")
+            animation.fromValue = layer.opacity
+            animation.toValue = target
+            animation.duration = duration
+            animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            layer.add(animation, forKey: "opacity")
         }
 
         layer.opacity = target
     }
 
-    private func processImage(_ image: NSImage, color: NSColor = .textColor) -> NSImage? {
+    private func processImage(_ image: NSImage, color: NSColor) -> NSImage? {
         guard image.isTemplate else { return image }
         let image = image.withSymbolConfiguration(.init(pointSize: 12, weight: .bold)) ?? image
 


### PR DESCRIPTION
For some time, the SwiftUI-based `IconView` has occasionally caused issues. The most notable problem was that it could lag one state behind after a user updated a selection in the keybinds tab. Other issues included stuttering animations and high rendering costs, although the latter could potentially have been optimized within SwiftUI itself.

By switching to a dedicated `NSView` backed by `CALayers` for rendering icons, we gain more control over when the view updates and benefit from a more lightweight rendering backend. This allows Loop to focus its resources on higher-priority tasks in the settings window.