### PR TITLE
🐞 Fix double click trigger

### DIFF
--- a/Loop/Core/Observers/Helpers/DoubleClickTimer.swift
+++ b/Loop/Core/Observers/Helpers/DoubleClickTimer.swift
@@ -31,8 +31,9 @@ final class DoubleClickTimer {
 
         if let last = lastTriggerKeyReleaseTime, now.timeIntervalSince(last) < doubleClickInterval {
             openCallback(startingAction)
-            lastTriggerKeyReleaseTime = nil
         }
+        
+        lastTriggerKeyReleaseTime = nil
     }
 
     /// Handles a key up event.

--- a/Loop/Core/Observers/Helpers/DoubleClickTimer.swift
+++ b/Loop/Core/Observers/Helpers/DoubleClickTimer.swift
@@ -32,7 +32,7 @@ final class DoubleClickTimer {
         if let last = lastTriggerKeyReleaseTime, now.timeIntervalSince(last) < doubleClickInterval {
             openCallback(startingAction)
         }
-        
+
         lastTriggerKeyReleaseTime = nil
     }
 

--- a/Loop/Core/Observers/Helpers/DoubleClickTimer.swift
+++ b/Loop/Core/Observers/Helpers/DoubleClickTimer.swift
@@ -13,27 +13,31 @@ import Defaults
 /// It tracks the timing of successive trigger actions (such as key presses) and determines whether
 /// two occur within the system-defined (and user-customizable) `NSEvent.doubleClickInterval`.
 final class DoubleClickTimer {
-    private var lastTriggerKeyPressTime: Date?
+    private var lastTriggerKeyReleaseTime: Date?
     private let openCallback: (WindowAction) -> ()
-    private var doubleClickInterval: TimeInterval { NSEvent.doubleClickInterval }
+    private var doubleClickInterval: TimeInterval = 0.5
 
     /// Creates a new `DoubleClickTimer` instance with the specified callback to invoke on a double-press event.
-    /// - Parameter openCallback: A closure that is called when a double-click is detected. The closure receives the `WindowAction` associated with the trigger as its parameter.
+    /// - Parameter openCallback: A closure called when a double-press is detected. Receives the associated `WindowAction`.
     init(openCallback: @escaping (WindowAction) -> ()) {
         self.openCallback = openCallback
     }
 
-    /// Handles a trigger event (such as a key press) and determines whether it qualifies as a "double-click".
-    /// - Parameter startingAction: The `WindowAction` associated with the trigger.
-    func handleTrigger(startingAction: WindowAction) {
+    /// Handles a key down event.
+    /// Triggers the callback if this qualifies as a double-press, otherwise records the press time.
+    /// - Parameter action: The `WindowAction` associated with this key down.
+    func handleKeyDown(startingAction: WindowAction) {
         let now = Date()
 
-        // If we detect a double-press, trigger immediately. Otherwise, just record the time
-        if let last = lastTriggerKeyPressTime, now.timeIntervalSince(last) < doubleClickInterval {
+        if let last = lastTriggerKeyReleaseTime, now.timeIntervalSince(last) < doubleClickInterval {
             openCallback(startingAction)
-            lastTriggerKeyPressTime = nil
-        } else {
-            lastTriggerKeyPressTime = now
+            lastTriggerKeyReleaseTime = nil
         }
+    }
+
+    /// Handles a key up event.
+    /// Updates the last trigger time without firing the callback.
+    func handleKeyUp() {
+        lastTriggerKeyReleaseTime = Date()
     }
 }

--- a/Loop/Core/Observers/KeybindTrigger.swift
+++ b/Loop/Core/Observers/KeybindTrigger.swift
@@ -200,6 +200,9 @@ final class KeybindTrigger {
                     return .opening
                 }
             } else {
+                if allPressedKeys.isEmpty {
+                    doubleClickTimer.handleKeyUp()
+                }
                 closeLoop(forceClose: false)
             }
         }
@@ -213,7 +216,7 @@ final class KeybindTrigger {
             openCallback(startingAction) // Only update Loop to the latest WindowAction
         } else {
             if doubleClickToTrigger {
-                doubleClickTimer.handleTrigger(startingAction: startingAction)
+                doubleClickTimer.handleKeyDown(startingAction: startingAction)
             } else if useTriggerDelay {
                 startTriggerDelayTimer(
                     startingAction: startingAction,

--- a/Loop/Core/Observers/MiddleClickTrigger.swift
+++ b/Loop/Core/Observers/MiddleClickTrigger.swift
@@ -76,13 +76,14 @@ final class MiddleClickTrigger {
             if event.type == .otherMouseDown,
                event.getIntegerValueField(.mouseEventButtonNumber) == 2 {
                 if doubleClickToTrigger {
-                    doubleClickTimer.handleTrigger(startingAction: .init(.noSelection))
+                    doubleClickTimer.handleKeyDown(startingAction: .init(.noSelection))
                 } else if useTriggerDelay {
                     triggerDelayTimer.handleTrigger(startingAction: .init(.noSelection))
                 } else {
                     openCallback(.init(.noSelection))
                 }
             } else {
+                doubleClickTimer.handleKeyUp()
                 triggerDelayTimer.cancel()
                 closeCallback(false)
             }


### PR DESCRIPTION
The double click listener will now listen to the change in time between a key release and a key press, instead of two key presses.