### PR TITLE
✨ Introduce TriggerKeyTimeout

### DIFF
--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -23,6 +23,10 @@ final class LoopManager: ObservableObject {
     private let radialMenuController = RadialMenuController()
     private let previewController = PreviewController()
 
+    private lazy var triggerKeyTimeoutTimer = TriggerKeyTimeoutTimer(
+        closeCallback: { [weak self] in self?.closeLoop(forceClose: $0) }
+    )
+
     private(set) lazy var keybindTrigger = KeybindTrigger(
         windowActionCache: windowActionCache,
         openCallback: { [weak self] in self?.openLoop(startingAction: $0) },
@@ -153,6 +157,8 @@ extension LoopManager {
 
         isLoopActive = true
         changeAction(startingAction, disableHapticFeedback: true)
+
+        triggerKeyTimeoutTimer.start()
     }
 
     private func closeLoop(forceClose: Bool) {
@@ -161,6 +167,8 @@ extension LoopManager {
 
         closeWindows()
         isLoopActive = false
+
+        triggerKeyTimeoutTimer.cancel()
 
         Task { @MainActor in
             mouseInteractionObserver.stop()
@@ -244,6 +252,9 @@ extension LoopManager {
         }
 
         var newAction = newAction
+
+        triggerKeyTimeoutTimer.cancel()
+        triggerKeyTimeoutTimer.start()
 
         if StashManager.shared.handleIfStashed(newAction, screen: currentScreen) {
             return

--- a/Loop/Core/Observers/Helpers/TriggerKeyTimeoutTimer.swift
+++ b/Loop/Core/Observers/Helpers/TriggerKeyTimeoutTimer.swift
@@ -1,0 +1,56 @@
+//
+//  TriggerKeyTimeoutTimer.swift
+//  Loop
+//
+//  Created by Kami on 06/01/2026.
+//
+
+import Defaults
+import Foundation
+
+/// A utility class that automatically closes Loop if no action is taken within a specified timeout period.
+///
+/// This timer starts when Loop is opened and automatically triggers the close callback if the user
+/// doesn't perform any action within the configured timeout duration (defined by `Defaults[.triggerKeyTimeout]`).
+/// The timer can be canceled if the user performs an action or manually closes Loop.
+final class TriggerKeyTimeoutTimer {
+    private var timeoutTimer: Task<(), Never>?
+    private let closeCallback: (Bool) -> ()
+    private var timeout: CGFloat { Defaults[.triggerKeyTimeout] }
+
+    /// Indicates whether the timeout timer is currently active.
+    var isActive: Bool { timeoutTimer != nil }
+
+    /// Creates a new `TriggerKeyTimeoutTimer` instance with the specified callback to invoke after the timeout elapses.
+    /// - Parameter closeCallback: A closure that is called once the timeout completes. The closure receives a boolean indicating whether to force close.
+    init(closeCallback: @escaping (Bool) -> ()) {
+        self.closeCallback = closeCallback
+    }
+
+    deinit {
+        cancel()
+    }
+
+    /// Starts the timeout timer. If Loop is still open when the timeout elapses, the close callback is invoked.
+    ///
+    /// This should be called when Loop is opened. If a timeout is already active, it will be canceled and restarted.
+    func start() {
+        guard timeout > 0 else { return }
+
+        cancel() // Ensure no previous timer is active
+
+        timeoutTimer = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(timeout))
+            guard !Task.isCancelled else { return }
+
+            closeCallback(false) // Auto-close without forcing
+            cancel()
+        }
+    }
+
+    /// Cancels any active timeout timer.
+    func cancel() {
+        timeoutTimer?.cancel()
+        timeoutTimer = nil
+    }
+}

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -125,6 +125,12 @@ extension Defaults.Keys {
     /// Reset with `defaults delete com.MrKai77.Loop updatesEnabled`
     static let updatesEnabled = Key<Bool>("updatesEnabled", default: true, iCloud: true)
 
+    /// Trigger key timeout, defined in seconds. Automatically closes Loop if no action is taken within the specified time.
+    /// When set to 0 (default: disabled), the feature is disabled and Loop stays open until manually closed.
+    /// Adjust with `defaults write com.MrKai77.Loop triggerKeyTimeout -float x`
+    /// Reset with `defaults delete com.MrKai77.Loop triggerKeyTimeout`
+    static let triggerKeyTimeout = Key<Double>("triggerKeyTimeout", default: 0, iCloud: true)
+
     // Migrator
     static let lastMigratorURL = Key<URL?>("lastMigratorURL", default: nil)
 


### PR DESCRIPTION
This PR introduces a new way of automatically disabling Loops trigger after a set period; this time can be set for anything the user wishes.
```shell
# Enable with 1 second timeout
defaults write com.MrKai77.Loop triggerKeyTimeout -float 1.0

# Disable (default)
defaults write com.MrKai77.Loop triggerKeyTimeout -float 0

# Check current value
defaults read com.MrKai77.Loop triggerKeyTimeout

# Remove setting
defaults delete com.MrKai77.Loop triggerKeyTimeout
```