### PR TITLE
🐞 Fix side-dependent keybind action keys

### DIFF
--- a/Loop/Core/Observers/KeybindTrigger.swift
+++ b/Loop/Core/Observers/KeybindTrigger.swift
@@ -151,7 +151,7 @@ final class KeybindTrigger {
     private func performKeybind(type: CGEventType, isARepeat: Bool, flags: CGEventFlags, isLoopOpen: Bool) -> PerformKeybindResult {
         let flagKeys = sideDependentTriggerKey ? flags.keyCodes : flags.keyCodes.baseModifiers
         let allPressedKeys: Set<CGKeyCode> = pressedKeys.union(flagKeys)
-        let actionKeys: Set<CGKeyCode> = allPressedKeys.subtracting(triggerKey)
+        let actionKeys: Set<CGKeyCode> = Set(allPressedKeys.subtracting(triggerKey).map(\.baseModifier))
         let containsTrigger = allPressedKeys.isSuperset(of: triggerKey)
 
         if isLoopOpen {

--- a/Loop/Settings Window/Settings/Keybinds/Keybind Recorder/Keycorder.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Keybind Recorder/Keycorder.swift
@@ -140,7 +140,7 @@ struct Keycorder: View {
         }
 
         // Filter out trigger keys from flags
-        let validModifiers = flags.keyCodes.filter {
+        let validModifiers = flags.keyCodes.map(\.baseModifier).filter {
             !Defaults[.triggerKey]
                 .map(\.baseModifier)
                 .contains($0)


### PR DESCRIPTION
This PR makes it so that action keys for keybinds are side-independent, as they should have been. This likely stopped working when we started detecting side-dependent modifiers via modifier flags instead of keyDown/keyUp events.