### PR TITLE
✨ Update "The Loop Times" window

### DIFF
--- a/Loop/Updater/UpdateView.swift
+++ b/Loop/Updater/UpdateView.swift
@@ -5,6 +5,7 @@
 //  Created by Kami on 15/06/2024.
 //
 
+import Defaults
 import Luminare
 import SwiftUI
 
@@ -12,19 +13,46 @@ struct UpdateView: View {
     @Environment(\.luminareTintColor) var tintColor
     @Environment(\.luminareAnimation) var luminareAnimation
     @Environment(\.colorScheme) var colorScheme
-
     @ObservedObject var updater = Updater.shared
-    @State var isInstalling: Bool = false
-    @State var readyToRestart: Bool = false
+
+    @Default(.currentIcon) private var currentIcon
+
+    @State private var isShowingTheLoopTimes: Bool = false
+    @State private var isInstalling: Bool = false
+    @State private var readyToRestart: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(spacing: 12) {
-                theLoopTimesView()
-                versionChangeView()
+            VStack(spacing: 8) {
+                if isShowingTheLoopTimes {
+                    theLoopTimesView()
+                        .padding(.top, 18)
+                        .padding(.bottom, 8)
+                        .contentShape(.rect)
+                        .onTapGesture {
+                            withAnimation(.smooth(duration: 0.25)) {
+                                isShowingTheLoopTimes.toggle()
+                            }
+                        }
+
+                    VStack(spacing: 4) {
+                        Divider()
+
+                        updateDateView()
+
+                        Divider()
+                    }
+                } else {
+                    appIconView()
+                        .onTapGesture {
+                            withAnimation(.smooth(duration: 0.25)) {
+                                isShowingTheLoopTimes.toggle()
+                            }
+                        }
+
+                    versionChangeView()
+                }
             }
-            .padding([.top, .horizontal], 12)
-            .padding(.bottom, 10)
 
             changelogView()
                 .mask {
@@ -38,76 +66,13 @@ struct UpdateView: View {
                     )
                 }
 
-            HStack {
-                Button("Remind me later") {
-                    Updater.shared.dismissWindow()
-                }
-                .disabled(isInstalling || readyToRestart)
-
-                Button {
-                    if readyToRestart {
-                        AppDelegate.relaunch()
-                    }
-
-                    withAnimation(luminareAnimation) {
-                        isInstalling = true
-                    }
-                    Task {
-                        await Updater.shared.installUpdate()
-
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                            withAnimation(luminareAnimation) {
-                                isInstalling = false
-                            }
-                            withAnimation(luminareAnimation) {
-                                readyToRestart = true
-                            }
-                        }
-                    }
-                } label: {
-                    ZStack {
-                        if isInstalling {
-                            Capsule()
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 5)
-                                .foregroundStyle(.quinary)
-                                .overlay {
-                                    GeometryReader { geo in
-                                        Capsule()
-                                            .foregroundStyle(tintColor)
-                                            .frame(width: CGFloat(updater.progressBar) * geo.size.width)
-                                            .animation(.smooth(duration: 0.8), value: updater.progressBar)
-                                            .shadow(color: tintColor.opacity(0.1), radius: 12)
-                                            .shadow(color: tintColor.opacity(0.4), radius: 6)
-                                            .shadow(color: tintColor, radius: 1)
-                                    }
-                                }
-                                .padding(.horizontal, 12)
-                        }
-
-                        let tenSpaces = "          " // This helps with alignment for the animation once the update finishes
-                        Text(isInstalling ? tenSpaces : readyToRestart ? NSLocalizedString("Relaunch to complete", comment: "") : NSLocalizedString("Install", comment: ""))
-                            .contentTransition(.numericText())
-                            .opacity(isInstalling ? 0 : 1)
-                    }
-                }
-                .allowsHitTesting(!isInstalling)
-            }
-            .luminareCornerRadius(8)
-            .padding(12)
-            .background(VisualEffectView(material: .menu, blendingMode: .behindWindow))
-            .overlay {
-                VStack {
-                    Divider()
-                    Spacer()
-                }
-            }
-            .fixedSize(horizontal: false, vertical: true)
+            footerView()
         }
-        .frame(width: 570, height: 480)
+        .frame(width: 500, height: 480)
     }
 
-    func theLoopTimesView() -> some View {
+    @ViewBuilder
+    private func theLoopTimesView() -> some View {
         ZStack {
             if colorScheme == .dark {
                 TheLoopTimes()
@@ -135,54 +100,73 @@ struct UpdateView: View {
                 .blendMode(.luminosity)
         }
         .aspectRatio(883.88 / 135.53, contentMode: .fit)
-        .frame(width: 450)
+        .frame(width: 400)
     }
 
-    func versionChangeView() -> some View {
-        ZStack {
-            versionChangeText()
-                .foregroundStyle(.primary.opacity(0.7))
-                .blendMode(.overlay)
+    @ViewBuilder
+    private func appIconView() -> some View {
+        if let image = NSImage(named: currentIcon) {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 128)
+        }
+    }
 
-            if colorScheme == .light {
-                versionChangeText()
-                    .blendMode(.overlay)
+    private func updateDateView() -> some View {
+        ZStack {
+            if let updateDate = updater.targetRelease?.updateDate {
+                Text(updateDate.formatted(date: .complete, time: .shortened))
+                    .fontDesign(.serif)
+                    .foregroundStyle(.tertiary)
+                    .fontWeight(.medium)
+            } else {
+                versionChangeView()
             }
         }
     }
 
-    func versionChangeText() -> some View {
+    private func versionChangeView() -> some View {
+        ZStack {
+            versionChangeText()
+                .foregroundStyle(.tertiary)
+                .fontWeight(.medium)
+        }
+    }
+
+    private func versionChangeText() -> some View {
         HStack {
             if let targetRelease = updater.targetRelease {
-                // Use UserDefaults to check if development versions are included
-                let isDevBuild = UserDefaults.standard.bool(forKey: "includeDevelopmentVersions")
+                let devBuildEmoji = "🧪"
+                let currentIsDevBuild: Bool = Bundle.main.appVersion?.contains(devBuildEmoji) ?? false
                 let targetIsDevBuild = targetRelease.prerelease
-                let devBuildEmoji = "🧪 "
 
-                let currentVersionBase = Bundle.main.appVersion?.replacing(devBuildEmoji, with: "") ?? "Unknown"
-                // Apply devBuildEmoji based on UserDefaults setting
-                let currentVersion = "\(isDevBuild ? devBuildEmoji : "")\(currentVersionBase) (\(Bundle.main.appBuild ?? 0))"
+                let currentVersionBase = Bundle.main.appVersion?.replacing(devBuildEmoji, with: "").trimmingCharacters(in: .whitespaces)
+                let targetVersionBase = targetRelease.tagName.replacing(devBuildEmoji, with: "").trimmingCharacters(in: .whitespaces)
+
+                let currentVersionBuild = currentIsDevBuild ? " (\(Bundle.main.appBuild ?? 0))" : ""
+                let targetVersionBuild = targetIsDevBuild ? " (\(targetRelease.buildNumber ?? 0))" : ""
+
+                let currentVersion = "\(currentIsDevBuild ? devBuildEmoji : "")\(currentVersionBase ?? "Unknown")\(currentVersionBuild)"
                 Text(currentVersion)
 
                 Image(systemName: "arrow.right")
 
-                let newVersionBase = targetRelease.tagName.replacing(devBuildEmoji, with: "")
-                // Apply devBuildEmoji to the new version if it's a dev build and the setting is enabled
-                let newVersion = "\(targetIsDevBuild && isDevBuild ? devBuildEmoji : "")\(newVersionBase) (\(targetRelease.buildNumber ?? 0))"
-                Text(newVersion)
+                let targetVersion = "\(targetIsDevBuild ? devBuildEmoji : "")\(targetVersionBase)\(targetVersionBuild)"
+                Text(targetVersion)
             } else {
                 let currentVersion = Bundle.main.appVersion ?? "Unknown"
                 Text(currentVersion)
 
                 Image(systemName: "arrow.right")
 
-                let newVersion = "Unknown"
-                Text(newVersion)
+                let targetVersion = "Unknown"
+                Text(targetVersion)
             }
         }
     }
 
-    func changelogView() -> some View {
+    private func changelogView() -> some View {
         ScrollView(showsIndicators: false) {
             VStack { // Using LazyVStack seems to cause visual glitches
                 ForEach(updater.changelog, id: \.title) { item in
@@ -208,6 +192,73 @@ struct UpdateView: View {
             .padding(.top, 10)
             .padding(12)
         }
+    }
+
+    private func footerView() -> some View {
+        HStack {
+            Button("Remind me later") {
+                Updater.shared.dismissWindow()
+            }
+            .disabled(isInstalling || readyToRestart)
+
+            Button {
+                if readyToRestart {
+                    AppDelegate.relaunch()
+                }
+
+                withAnimation(luminareAnimation) {
+                    isInstalling = true
+                }
+                Task {
+                    await Updater.shared.installUpdate()
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                        withAnimation(luminareAnimation) {
+                            isInstalling = false
+                        }
+                        withAnimation(luminareAnimation) {
+                            readyToRestart = true
+                        }
+                    }
+                }
+            } label: {
+                ZStack {
+                    if isInstalling {
+                        Capsule()
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 5)
+                            .foregroundStyle(.quinary)
+                            .overlay {
+                                GeometryReader { geo in
+                                    Capsule()
+                                        .foregroundStyle(tintColor)
+                                        .frame(width: CGFloat(updater.progressBar) * geo.size.width)
+                                        .animation(.smooth(duration: 0.8), value: updater.progressBar)
+                                        .shadow(color: tintColor.opacity(0.1), radius: 12)
+                                        .shadow(color: tintColor.opacity(0.4), radius: 6)
+                                        .shadow(color: tintColor, radius: 1)
+                                }
+                            }
+                            .padding(.horizontal, 12)
+                    }
+
+                    let tenSpaces = "          " // This helps with alignment for the animation once the update finishes
+                    Text(isInstalling ? tenSpaces : readyToRestart ? NSLocalizedString("Relaunch to complete", comment: "") : NSLocalizedString("Install", comment: ""))
+                        .contentTransition(.numericText())
+                        .opacity(isInstalling ? 0 : 1)
+                }
+            }
+            .allowsHitTesting(!isInstalling)
+        }
+        .luminareCornerRadius(8)
+        .padding(12)
+        .overlay {
+            VStack {
+                Divider()
+                Spacer()
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/Loop/Updater/Updater.swift
+++ b/Loop/Updater/Updater.swift
@@ -209,6 +209,8 @@ final class Updater: ObservableObject {
 
     private func processFetchedData(_ data: Data) async throws {
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
         if includeDevelopmentVersions {
             // This would need to parse a list of releases
             let releases = try decoder.decode([Release].self, from: data)
@@ -481,11 +483,13 @@ struct Release: Codable {
     var body: String
     var assets: [Asset]
     var prerelease: Bool
+    var creationDate: Date
+    var updateDate: Date
 
     var buildNumber: Int?
 
     enum CodingKeys: String, CodingKey {
-        case id, tagName = "tag_name", name, body, assets, prerelease
+        case id, tagName = "tag_name", name, body, assets, prerelease, creationDate = "created_at", updateDate = "updated_at"
     }
 
     struct Asset: Codable {


### PR DESCRIPTION
A common piece of feedback has been that the Loop update window looks suspicious or untrustworthy. While I don’t personally agree, it’s more important for Loop to feel trustworthy to users than to prioritize a unique design that could be misinterpreted as malicious.

As a bonus, you can now click the Loop icon to restore the previous layout and view the update’s release date.