### PR TITLE
✨ Ability to launch Loop hidden, add bottom stash option

### DIFF
--- a/Loop/App/AppDelegate.swift
+++ b/Loop/App/AppDelegate.swift
@@ -31,7 +31,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await Defaults.iCloud.waitForSyncCompletion()
         }
 
-        if !launchedAsLoginItem {
+        // Show settings window only if not launched as login item AND startHidden is disabled
+        if !launchedAsLoginItem, !Defaults[.startHidden] {
             SettingsWindowManager.shared.show()
         } else {
             // Closing also hides the dock icon if needed.

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -41,6 +41,7 @@ extension Defaults.Keys {
 
     // Behavior
     static let launchAtLogin = Key<Bool>("launchAtLogin", default: false, iCloud: true)
+    static let startHidden = Key<Bool>("startHidden", default: false, iCloud: true)
     static let hideMenuBarIcon = Key<Bool>("hideMenuBarIcon", default: false, iCloud: false)
     static let animationConfiguration = Key<AnimationConfiguration>("animationConfiguration", default: .snappy, iCloud: true)
     static let windowSnapping = Key<Bool>("windowSnapping", default: false, iCloud: true)

--- a/Loop/Extensions/NSScreen+Extensions.swift
+++ b/Loop/Extensions/NSScreen+Extensions.swift
@@ -193,29 +193,6 @@ extension NSScreen {
         return bestScreen ?? self
     }
 
-    func topmostScreenInSameColumn(overlapThreshold: CGFloat = 10.0) -> NSScreen {
-        let sameColumnScreens = screensInSameColumn(screens: NSScreen.screens, overlapThreshold: overlapThreshold)
-
-        let topCandidates = sameColumnScreens.filter { $0.frame.maxY <= self.frame.minY }
-
-        guard !topCandidates.isEmpty else {
-            return self
-        }
-
-        var bestScreen: NSScreen? = nil
-        var bestOverlap: CGFloat = -1
-
-        for screen in topCandidates {
-            let overlap = horizontalOverlap(with: screen)
-            if overlap > bestOverlap || (overlap == bestOverlap && screen.frame.minY < bestScreen?.frame.minY ?? .infinity) {
-                bestScreen = screen
-                bestOverlap = overlap
-            }
-        }
-
-        return bestScreen ?? self
-    }
-
     func bottommostScreenInSameColumn(overlapThreshold: CGFloat = 10.0) -> NSScreen {
         let sameColumnScreens = screensInSameColumn(screens: NSScreen.screens, overlapThreshold: overlapThreshold)
 

--- a/Loop/Extensions/NSScreen+Extensions.swift
+++ b/Loop/Extensions/NSScreen+Extensions.swift
@@ -130,8 +130,21 @@ extension NSScreen {
         return max(0, bottom - top)
     }
 
+    private func horizontalOverlap(with other: NSScreen) -> CGFloat {
+        let a = frame
+        let b = other.frame
+
+        let left = max(a.minX, b.minX)
+        let right = min(a.maxX, b.maxX)
+        return max(0, right - left)
+    }
+
     private func screensInSameRow(screens: [NSScreen], overlapThreshold: CGFloat = 10.0) -> [NSScreen] {
         screens.filter { verticalOverlap(with: $0) >= overlapThreshold }
+    }
+
+    private func screensInSameColumn(screens: [NSScreen], overlapThreshold: CGFloat = 10.0) -> [NSScreen] {
+        screens.filter { horizontalOverlap(with: $0) >= overlapThreshold }
     }
 
     func leftmostScreenInSameRow(overlapThreshold: CGFloat = 10.0) -> NSScreen {
@@ -172,6 +185,52 @@ extension NSScreen {
         for screen in rightCandidates {
             let overlap = verticalOverlap(with: screen)
             if overlap > bestOverlap || (overlap == bestOverlap && screen.frame.maxX > bestScreen?.frame.maxX ?? -.infinity) {
+                bestScreen = screen
+                bestOverlap = overlap
+            }
+        }
+
+        return bestScreen ?? self
+    }
+
+    func topmostScreenInSameColumn(overlapThreshold: CGFloat = 10.0) -> NSScreen {
+        let sameColumnScreens = screensInSameColumn(screens: NSScreen.screens, overlapThreshold: overlapThreshold)
+
+        let topCandidates = sameColumnScreens.filter { $0.frame.maxY <= self.frame.minY }
+
+        guard !topCandidates.isEmpty else {
+            return self
+        }
+
+        var bestScreen: NSScreen? = nil
+        var bestOverlap: CGFloat = -1
+
+        for screen in topCandidates {
+            let overlap = horizontalOverlap(with: screen)
+            if overlap > bestOverlap || (overlap == bestOverlap && screen.frame.minY < bestScreen?.frame.minY ?? .infinity) {
+                bestScreen = screen
+                bestOverlap = overlap
+            }
+        }
+
+        return bestScreen ?? self
+    }
+
+    func bottommostScreenInSameColumn(overlapThreshold: CGFloat = 10.0) -> NSScreen {
+        let sameColumnScreens = screensInSameColumn(screens: NSScreen.screens, overlapThreshold: overlapThreshold)
+
+        let bottomCandidates = sameColumnScreens.filter { $0.frame.minY >= self.frame.maxY }
+
+        guard !bottomCandidates.isEmpty else {
+            return self
+        }
+
+        var bestScreen: NSScreen? = nil
+        var bestOverlap: CGFloat = -1
+
+        for screen in bottomCandidates {
+            let overlap = horizontalOverlap(with: screen)
+            if overlap > bestOverlap || (overlap == bestOverlap && screen.frame.maxY > bestScreen?.frame.maxY ?? -.infinity) {
                 bestScreen = screen
                 bestOverlap = overlap
             }

--- a/Loop/Localizable.xcstrings
+++ b/Loop/Localizable.xcstrings
@@ -11830,6 +11830,16 @@
         }
       }
     },
+    "Start hidden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start hidden"
+          }
+        }
+      }
+    },
     "Left" : {
       "comment" : "Label for a slider in Loop’s padding settings\nSide of a trigger key",
       "localizations" : {

--- a/Loop/Settings Window/Settings/Behavior/BehaviorConfiguration.swift
+++ b/Loop/Settings Window/Settings/Behavior/BehaviorConfiguration.swift
@@ -13,6 +13,7 @@ struct BehaviorConfigurationView: View {
     @Environment(\.luminareAnimation) private var luminareAnimation
 
     @Default(.launchAtLogin) var launchAtLogin
+    @Default(.startHidden) var startHidden
     @Default(.hideMenuBarIcon) var hideMenuBarIcon
     @Default(.animationConfiguration) var animationConfiguration
     @Default(.windowSnapping) var windowSnapping
@@ -54,6 +55,8 @@ struct BehaviorConfigurationView: View {
     private var generalSection: some View {
         LuminareSection(String(localized: "General", comment: "Section header shown in settings")) {
             LuminareToggle("Launch at login", isOn: $launchAtLogin)
+
+            LuminareToggle("Start hidden", isOn: $startHidden)
 
             LuminareToggle("Hide menu bar icon", isOn: $hideMenuBarIcon)
 

--- a/Loop/Settings Window/Settings/Keybinds/Modal Views/CustomActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Modal Views/CustomActionConfigurationView.swift
@@ -229,7 +229,9 @@ struct CustomActionConfigurationView: View {
                     ),
                     columns: 3
                 ) { anchor in
-                    IconView(action: anchor.iconAction)
+                    if let action = anchor.iconAction {
+                        IconView(action: action)
+                    }
                 }
                 .luminareRoundingBehavior(bottom: !showMacOSCenterToggle)
 

--- a/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
@@ -38,6 +38,7 @@ struct StashActionConfigurationView: View {
     private var anchors: [CustomWindowActionAnchor] {
         [.topLeft, .top, .topRight,
          .left, .center, .right,
+         .left, .none, .right,
          .bottomLeft, .bottom, .bottomRight]
     }
 
@@ -196,7 +197,9 @@ struct StashActionConfigurationView: View {
                     ),
                     columns: 3
                 ) { anchor in
-                    IconView(action: anchor.iconAction)
+                    if let action = anchor.iconAction {
+                        IconView(action: action)
+                    }
                 }
                 .luminareRoundingBehavior(top: true, bottom: true)
             } else {

--- a/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
@@ -36,8 +36,7 @@ struct StashActionConfigurationView: View {
     private let defaultAnchor: CustomWindowActionAnchor = .topLeft
 
     private var anchors: [CustomWindowActionAnchor] {
-        [.topLeft, .top, .topRight,
-         .left, .center, .right,
+        [.topLeft, .none, .topRight,
          .left, .none, .right,
          .bottomLeft, .bottom, .bottomRight]
     }

--- a/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
@@ -36,7 +36,9 @@ struct StashActionConfigurationView: View {
     private let defaultAnchor: CustomWindowActionAnchor = .topLeft
 
     private var anchors: [CustomWindowActionAnchor] {
-        [.topLeft, .topRight, .left, .right, .bottomLeft, .bottomRight]
+        [.topLeft, .top, .topRight,
+         .left, .center, .right,
+         .bottomLeft, .bottom, .bottomRight]
     }
 
     private var sizeModes: [CustomWindowActionSizeMode] {
@@ -192,7 +194,7 @@ struct StashActionConfigurationView: View {
                             }
                         }
                     ),
-                    columns: 2
+                    columns: 3
                 ) { anchor in
                     IconView(action: anchor.iconAction)
                 }

--- a/Loop/Stashing/StashDirection.swift
+++ b/Loop/Stashing/StashDirection.swift
@@ -11,9 +11,19 @@ import Foundation
 enum StashEdge: String, CustomDebugStringConvertible {
     case left
     case right
+    case top
+    case bottom
 
     var debugDescription: String {
         rawValue
+    }
+
+    var isHorizontal: Bool {
+        self == .left || self == .right
+    }
+
+    var isVertical: Bool {
+        self == .top || self == .bottom
     }
 }
 
@@ -22,9 +32,21 @@ enum StashEdge: String, CustomDebugStringConvertible {
 extension WindowAction {
     var stashEdge: StashEdge? {
         switch direction {
-        case .stash where [.left, .topLeft, .bottomLeft].contains(anchor):
+        case .stash where anchor == .left:
             .left
-        case .stash where [.right, .topRight, .bottomRight].contains(anchor):
+        case .stash where anchor == .right:
+            .right
+        case .stash where anchor == .top:
+            .top
+        case .stash where anchor == .bottom:
+            .bottom
+        case .stash where anchor == .topLeft:
+            .left
+        case .stash where anchor == .topRight:
+            .right
+        case .stash where anchor == .bottomLeft:
+            .left
+        case .stash where anchor == .bottomRight:
             .right
         default:
             nil

--- a/Loop/Stashing/StashDirection.swift
+++ b/Loop/Stashing/StashDirection.swift
@@ -11,7 +11,6 @@ import Foundation
 enum StashEdge: String, CustomDebugStringConvertible {
     case left
     case right
-    case top
     case bottom
 
     var debugDescription: String {
@@ -23,7 +22,7 @@ enum StashEdge: String, CustomDebugStringConvertible {
     }
 
     var isVertical: Bool {
-        self == .top || self == .bottom
+        self == .bottom
     }
 }
 
@@ -36,8 +35,6 @@ extension WindowAction {
             .left
         case .stash where anchor == .right:
             .right
-        case .stash where anchor == .top:
-            .top
         case .stash where anchor == .bottom:
             .bottom
         case .stash where anchor == .topLeft:

--- a/Loop/Stashing/StashManager.swift
+++ b/Loop/Stashing/StashManager.swift
@@ -62,7 +62,8 @@ final class StashManager {
 
     /// Two windows can be stacked along the same edge of the screen as long as there is enough non-overlapping space
     /// to allow the user to easily position the cursor over either window.
-    private let minimumVisibleHeightToKeepWindowStacked: CGFloat = 100
+    /// This applies to vertical space for horizontal edges (left/right) and horizontal space for vertical edges (top/bottom).
+    private let minimumVisibleSizeToKeepWindowStacked: CGFloat = 100
 
     private lazy var store: StashedWindowsStore = {
         let store = StashedWindowsStore()
@@ -373,12 +374,16 @@ private extension StashManager {
                 .mouseMoved, // Normal mouse movement
                 .leftMouseDragged // Dragging items to stashed windows
             ],
-            callback: handleMouseMoved
+            callback: { [weak self] cgEvent in
+                self?.handleMouseMoved(cgEvent: cgEvent)
+            }
         )
         monitor.start()
         mouseMonitor = monitor
 
-        frontmostAppMonitor = Task { @MainActor in
+        frontmostAppMonitor = Task { @MainActor [weak self] in
+            guard let self else { return }
+
             let notifications = NSWorkspace.shared.notificationCenter.notifications(
                 named: NSWorkspace.didActivateApplicationNotification
             )
@@ -395,10 +400,21 @@ private extension StashManager {
 
         log.info("Stopping listening for reveal triggers…")
 
-        mouseMonitor?.stop()
-        mouseMonitor = nil
+        // Cancel tasks first
         frontmostAppMonitor?.cancel()
         frontmostAppMonitor = nil
+
+        // Stop and release the monitor
+        // The monitor's deinit will handle cleanup of the event tap
+        mouseMonitor?.stop()
+
+        // Delay the release to allow the run loop to process the stop
+        let monitor = mouseMonitor
+        mouseMonitor = nil
+
+        DispatchQueue.main.async {
+            _ = monitor // Keep alive until run loop processes the removal
+        }
     }
 
     /// Handles mouse movement events with a debounce to avoid excessive processing.
@@ -523,9 +539,9 @@ private extension StashManager {
                 unstash(stashedWindow, resetFrame: true, resetFrameAnimated: animate)
             } else {
                 let currentFrame = stashedWindow.computeStashedFrame(peekSize: stashedWindowVisiblePadding)
-                let tolerance = minimumVisibleHeightToKeepWindowStacked
+                let tolerance = minimumVisibleSizeToKeepWindowStacked
 
-                if !isThereEnoughNonOverlappingSpace(between: newFrame, and: currentFrame, tolerance: tolerance) {
+                if !isThereEnoughNonOverlappingSpace(between: newFrame, and: currentFrame, edge: windowToStash.action.stashEdge, tolerance: tolerance) {
                     log.info("Trying to stash a window overlapping another one. Replacing…")
                     unstash(stashedWindow, resetFrame: true, resetFrameAnimated: animate)
                 }
@@ -535,21 +551,31 @@ private extension StashManager {
 
     /// Determines whether two rectangles have enough non-overlapping space between them.
     ///
-    /// This function compares the vertical ranges (y-axis) of two rectangles, `rect1` and `rect2`,
-    /// and checks if they are either non-overlapping or sufficiently offset vertically by at least
-    /// a given `tolerance` value. This ensures that if windows are stashed along the same edge of the screen,
-    /// they do not overlap each other and leave enough visible space (as defined by `tolerance`).
+    /// This function checks if windows stashed along the same edge have sufficient separation:
+    /// - For horizontal edges (left/right): compares vertical ranges (y-axis)
+    /// - For vertical edges (top/bottom): compares horizontal ranges (x-axis)
     ///
     /// - Parameters:
     ///   - rect1: The first rectangle representing a stashed window's frame.
     ///   - rect2: The second rectangle representing another window's frame.
-    ///   - tolerance: The minimum number of pixels that must separate the two windows (in the vertical direction).
+    ///   - edge: The edge where windows are stashed (determines which axis to check).
+    ///   - tolerance: The minimum number of pixels that must separate the two windows.
     ///
     /// - Returns: `true` if the two rectangles do not overlap or are separated by at least `tolerance` pixels;
     ///            `false` otherwise.
-    func isThereEnoughNonOverlappingSpace(between rect1: CGRect, and rect2: CGRect, tolerance: CGFloat) -> Bool {
-        let range1 = rect1.minY...rect1.maxY
-        let range2 = rect2.minY...rect2.maxY
+    func isThereEnoughNonOverlappingSpace(between rect1: CGRect, and rect2: CGRect, edge: StashEdge?, tolerance: CGFloat) -> Bool {
+        let range1: ClosedRange<CGFloat>
+        let range2: ClosedRange<CGFloat>
+
+        // For horizontal edges (left/right), check vertical overlap
+        // For vertical edges (top/bottom), check horizontal overlap
+        if edge?.isHorizontal == true {
+            range1 = rect1.minY...rect1.maxY
+            range2 = rect2.minY...rect2.maxY
+        } else {
+            range1 = rect1.minX...rect1.maxX
+            range2 = rect2.minX...rect2.maxX
+        }
 
         return areRangesNonOverlappingByAtLeast(tolerance, range1, range2)
     }
@@ -614,7 +640,7 @@ private extension StashManager {
     }
 
     func getScreenForEdge(currentScreen: NSScreen, edge: StashEdge) -> NSScreen? {
-        // Two screens are considered in the same "row" if they overlap vertically by at least `threshold` points
+        // Two screens are considered in the same "row" or "column" if they overlap by at least `threshold` points
         let threshold: CGFloat = 100
 
         return switch edge {
@@ -622,6 +648,10 @@ private extension StashManager {
             currentScreen.leftmostScreenInSameRow(overlapThreshold: threshold)
         case .right:
             currentScreen.rightmostScreenInSameRow(overlapThreshold: threshold)
+        case .top:
+            currentScreen.topmostScreenInSameColumn(overlapThreshold: threshold)
+        case .bottom:
+            currentScreen.bottommostScreenInSameColumn(overlapThreshold: threshold)
         }
     }
 }

--- a/Loop/Stashing/StashManager.swift
+++ b/Loop/Stashing/StashManager.swift
@@ -62,7 +62,7 @@ final class StashManager {
 
     /// Two windows can be stacked along the same edge of the screen as long as there is enough non-overlapping space
     /// to allow the user to easily position the cursor over either window.
-    /// This applies to vertical space for horizontal edges (left/right) and horizontal space for vertical edges (top/bottom).
+    /// This applies to vertical space for horizontal edges (left/right) and horizontal space for vertical edges (bottom).
     private let minimumVisibleSizeToKeepWindowStacked: CGFloat = 100
 
     private lazy var store: StashedWindowsStore = {
@@ -553,7 +553,7 @@ private extension StashManager {
     ///
     /// This function checks if windows stashed along the same edge have sufficient separation:
     /// - For horizontal edges (left/right): compares vertical ranges (y-axis)
-    /// - For vertical edges (top/bottom): compares horizontal ranges (x-axis)
+    /// - For vertical edges (bottom): compares horizontal ranges (x-axis)
     ///
     /// - Parameters:
     ///   - rect1: The first rectangle representing a stashed window's frame.
@@ -568,7 +568,7 @@ private extension StashManager {
         let range2: ClosedRange<CGFloat>
 
         // For horizontal edges (left/right), check vertical overlap
-        // For vertical edges (top/bottom), check horizontal overlap
+        // For vertical edges (bottom), check horizontal overlap
         if edge?.isHorizontal == true {
             range1 = rect1.minY...rect1.maxY
             range2 = rect2.minY...rect2.maxY
@@ -648,8 +648,6 @@ private extension StashManager {
             currentScreen.leftmostScreenInSameRow(overlapThreshold: threshold)
         case .right:
             currentScreen.rightmostScreenInSameRow(overlapThreshold: threshold)
-        case .top:
-            currentScreen.topmostScreenInSameColumn(overlapThreshold: threshold)
         case .bottom:
             currentScreen.bottommostScreenInSameColumn(overlapThreshold: threshold)
         }

--- a/Loop/Stashing/StashedWindowInfo.swift
+++ b/Loop/Stashing/StashedWindowInfo.swift
@@ -35,15 +35,10 @@ struct StashedWindowInfo: Equatable {
                 frame.origin.x = bounds.maxX - clampedPeekSize
             }
 
-        case .top, .bottom:
+        case .bottom:
             let maxPeekSize = frame.height * maxPeekPercent
             let clampedPeekSize = max(minPeekSize, min(peekSize, maxPeekSize))
-
-            if action.stashEdge == .top {
-                frame.origin.y = bounds.minY - frame.height + clampedPeekSize
-            } else {
-                frame.origin.y = bounds.maxY - clampedPeekSize
-            }
+            frame.origin.y = bounds.maxY - clampedPeekSize
 
         case .none:
             log.warn("Trying to compute the stash frame for a non-stash related action.")

--- a/Loop/Stashing/StashedWindowInfo.swift
+++ b/Loop/Stashing/StashedWindowInfo.swift
@@ -23,14 +23,28 @@ struct StashedWindowInfo: Equatable {
         var frame = WindowFrameResolver.getFrame(for: action, window: window, bounds: bounds)
 
         let minPeekSize: CGFloat = 1
-        let maxPeekSize = frame.width * maxPeekPercent
-        let clampedPeekSize = max(minPeekSize, min(peekSize, maxPeekSize))
 
         switch action.stashEdge {
-        case .left:
-            frame.origin.x = bounds.minX - frame.width + clampedPeekSize
-        case .right:
-            frame.origin.x = bounds.maxX - clampedPeekSize
+        case .left, .right:
+            let maxPeekSize = frame.width * maxPeekPercent
+            let clampedPeekSize = max(minPeekSize, min(peekSize, maxPeekSize))
+
+            if action.stashEdge == .left {
+                frame.origin.x = bounds.minX - frame.width + clampedPeekSize
+            } else {
+                frame.origin.x = bounds.maxX - clampedPeekSize
+            }
+
+        case .top, .bottom:
+            let maxPeekSize = frame.height * maxPeekPercent
+            let clampedPeekSize = max(minPeekSize, min(peekSize, maxPeekSize))
+
+            if action.stashEdge == .top {
+                frame.origin.y = bounds.minY - frame.height + clampedPeekSize
+            } else {
+                frame.origin.y = bounds.maxY - clampedPeekSize
+            }
+
         case .none:
             log.warn("Trying to compute the stash frame for a non-stash related action.")
         }

--- a/Loop/Window Management/Window Action/Custom Window Sizes/CustomWindowActionAnchor.swift
+++ b/Loop/Window Management/Window Action/Custom Window Sizes/CustomWindowActionAnchor.swift
@@ -5,11 +5,13 @@
 //  Created by Kai Azim on 2024-01-01.
 //
 
+import Luminare
 import SwiftUI
 
-enum CustomWindowActionAnchor: Int, Codable, CaseIterable, Identifiable {
+enum CustomWindowActionAnchor: Int, Codable, Identifiable, LuminareSelectionData {
     var id: Self { self }
 
+    case none = -1
     case topLeft = 0
     case top = 1
     case topRight = 2
@@ -20,18 +22,23 @@ enum CustomWindowActionAnchor: Int, Codable, CaseIterable, Identifiable {
     case left = 7
     case center = 8
     case macOSCenter = 9
+
+    var isSelectable: Bool {
+        self != .none
+    }
 }
 
 extension CustomWindowActionAnchor {
     private static var iconActionCache: [CustomWindowActionAnchor: WindowAction] = [:]
 
-    var iconAction: WindowAction {
+    var iconAction: WindowAction? {
         // Prevents re-initializing the same action multiple times
         if let cachedAction = CustomWindowActionAnchor.iconActionCache[self] {
             return cachedAction
         }
 
-        let newAction: WindowAction = switch self {
+        let newAction: WindowAction? = switch self {
+        case .none: nil
         case .topLeft: .init(.topLeftQuarter)
         case .top: .init(.topHalf)
         case .topRight: .init(.topRightQuarter)

--- a/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
+++ b/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
@@ -433,9 +433,9 @@ extension WindowFrameResolver {
             .filter { !$0.intersects(currentFrame) } // Ensure it doesn't intersect with the current window
             .map { $0.intersection(screenFrame) } // Crop it to the screen frame
 
-        /// Computes the closest window obstacle in each of the four cardinal directions
-        /// (left, right, top, bottom) relative to the current window, and returns the boundaries
-        /// formed by these obstacles, constrained to the screen frame.
+        // Computes the closest window obstacle in each of the four cardinal directions
+        // (left, right, top, bottom) relative to the current window, and returns the boundaries
+        // formed by these obstacles, constrained to the screen frame.
         func computeBoundaries() -> (minX: CGFloat, minY: CGFloat, maxX: CGFloat, maxY: CGFloat) {
             var minX = screenFrame.minX
             var minY = screenFrame.minY

--- a/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
+++ b/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
@@ -433,9 +433,9 @@ extension WindowFrameResolver {
             .filter { !$0.intersects(currentFrame) } // Ensure it doesn't intersect with the current window
             .map { $0.intersection(screenFrame) } // Crop it to the screen frame
 
-        // Computes the closest window obstacle in each of the four cardinal directions
-        // (left, right, top, bottom) relative to the current window, and returns the boundaries
-        // formed by these obstacles, constrained to the screen frame.
+        /// Computes the closest window obstacle in each of the four cardinal directions
+        /// (left, right, top, bottom) relative to the current window, and returns the boundaries
+        /// formed by these obstacles, constrained to the screen frame.
         func computeBoundaries() -> (minX: CGFloat, minY: CGFloat, maxX: CGFloat, maxY: CGFloat) {
             var minX = screenFrame.minX
             var minY = screenFrame.minY


### PR DESCRIPTION
This update aims to add two minor features requested by users: the ability to start up Loop without opening a window and to add stash windows to the top and bottom of the display.

A note for both: first, with Loop being hidden, if both the menu bar and the app on launch are hidden, and you're in development mode, i.e., opening it in Xcode, you will NOT be able to launch the window. You'll need to disable this before starting, or alternatively turn on the icon. If none of these are available, you can simply

```sh
defaults write com.MrKai77.Loop startHidden -bool false
```

Regarding window stashing, for stashing, the calculation is done, i.e., the math. If you have two window sizes, both previewing at 80%, it will remove the windows at the top and bottom. My recommendation here is to set the window width to be half of the maximum. For example, if you have two windows, instead of both being 50%, set them to 40-45% (given that both are stashed on the right-hand top and bottom of the screen).