### PR TITLE
🐞 Fix padding being applied to IconView previews

### DIFF
--- a/Loop/Window Management/Window Action/IconView.swift
+++ b/Loop/Window Management/Window Action/IconView.swift
@@ -185,7 +185,8 @@ final class IconRenderView: NSView {
         let frame = WindowFrameResolver.getFrame(
             for: currentAction,
             window: nil,
-            bounds: .init(origin: .zero, size: .init(width: 1, height: 1))
+            bounds: .init(origin: .zero, size: .init(width: 1, height: 1)),
+            padding: .zero
         ).flipY(maxY: 1)
 
         if frame.size.area != 0 {

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -40,13 +40,14 @@ final class ResizeContext {
         initialFrame: CGRect? = nil,
         screen: NSScreen? = nil,
         bounds: CGRect? = nil,
+        padding: PaddingConfiguration? = nil,
         action: WindowAction = .init(.noSelection),
         parentAction: WindowAction? = nil,
         initialMousePosition: CGPoint = .zero
     ) {
         let frame = initialFrame ?? window?.frame ?? .zero
         let bounds = bounds ?? screen?.cgSafeScreenFrame ?? .zero
-        let padding = PaddingConfiguration.getConfiguredPadding(for: screen)
+        let padding = padding ?? PaddingConfiguration.getConfiguredPadding(for: screen)
 
         self.window = window
         self.cachedTargetFrame = ComputedFrame(raw: frame, normalized: .zero, padded: frame)

--- a/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
+++ b/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
@@ -23,9 +23,10 @@ enum WindowFrameResolver {
     static func getFrame(
         for action: WindowAction,
         window: Window?,
-        bounds: CGRect
+        bounds: CGRect,
+        padding: PaddingConfiguration? = nil
     ) -> CGRect {
-        let context = ResizeContext(window: window, bounds: bounds, action: action)
+        let context = ResizeContext(window: window, bounds: bounds, padding: padding, action: action)
         return getFrame(resizeContext: context).frame
     }
 


### PR DESCRIPTION
IconView was applying padding to its icons, which caused them to appear as large filled rectangles. The fix disables padding for all IconViews, since they aren’t meant to be affected by it.