### PR TITLE
✨ Add 'Ignore notch' option for consistent top padding across screens

### DIFF
--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -319,7 +319,7 @@ extension LoopManager {
 
                         let adjustedBounds = PaddingConfiguration
                             .getConfiguredPadding(for: currentScreen)
-                            .applyToBounds(currentScreen.cgSafeScreenFrame)
+                            .applyToBounds(currentScreen.cgSafeScreenFrame, screen: currentScreen)
 
                         let proportionalSize = CGRect(
                             x: (currentFrame.minX - adjustedBounds.minX) / adjustedBounds.width,

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -106,6 +106,12 @@ extension Defaults.Keys {
     /// Reset with `defaults delete com.MrKai77.Loop paddingMinimumScreenSize`
     static let paddingMinimumScreenSize = Key<CGFloat>("paddingMinimumScreenSize", default: 0, iCloud: true)
 
+    /// Ignore the notch height when calculating top padding, so the effective
+    /// distance from the screen top matches non-notch displays.
+    /// Adjust with `defaults write com.MrKai77.Loop ignoreNotch -bool true`
+    /// Reset with `defaults delete com.MrKai77.Loop ignoreNotch`
+    static let ignoreNotch = Key<Bool>("ignoreNotch", default: false, iCloud: true)
+
     /// Snap threshold for window snapping, defined in points.
     /// Adjust with `defaults write com.MrKai77.Loop snapThreshold -float x`
     /// Reset with `defaults delete com.MrKai77.Loop snapThreshold`

--- a/Loop/Window Management/Window Manipulation/PaddingConfiguration.swift
+++ b/Loop/Window Management/Window Manipulation/PaddingConfiguration.swift
@@ -37,13 +37,21 @@ struct PaddingConfiguration: Codable, Defaults.Serializable, Hashable {
     }
 
     func applyToBounds(
-        _ bounds: CGRect
+        _ bounds: CGRect,
+        screen: NSScreen? = nil
     ) -> CGRect {
-        bounds
+        let notchOffset: CGFloat = if Defaults[.ignoreNotch], let screen {
+            screen.menubarHeight
+        } else {
+            0
+        }
+        let effectiveTopPadding = max(0, totalTopPadding - notchOffset)
+
+        return bounds
             .padding(.leading, left)
             .padding(.trailing, right)
             .padding(.bottom, bottom)
-            .padding(.top, totalTopPadding)
+            .padding(.top, effectiveTopPadding)
     }
 
     /// Applies padding to a frame that was calculated using non-padded bounds.

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -54,7 +54,7 @@ final class ResizeContext {
         self.screen = screen
         self.bounds = bounds
         self.padding = padding
-        self.paddedBounds = padding.applyToBounds(bounds)
+        self.paddedBounds = padding.applyToBounds(bounds, screen: screen)
         self.action = action
         self.parentAction = parentAction
         self.initialMousePosition = initialMousePosition
@@ -65,7 +65,7 @@ final class ResizeContext {
         self.screen = screen
         bounds = screen?.cgSafeScreenFrame ?? .zero
         padding = PaddingConfiguration.getConfiguredPadding(for: screen)
-        paddedBounds = padding.applyToBounds(bounds)
+        paddedBounds = padding.applyToBounds(bounds, screen: screen)
         needsRecompute = true
     }
 

--- a/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
+++ b/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
@@ -434,9 +434,9 @@ extension WindowFrameResolver {
             .filter { !$0.intersects(currentFrame) } // Ensure it doesn't intersect with the current window
             .map { $0.intersection(screenFrame) } // Crop it to the screen frame
 
-        // Computes the closest window obstacle in each of the four cardinal directions
-        // (left, right, top, bottom) relative to the current window, and returns the boundaries
-        // formed by these obstacles, constrained to the screen frame.
+        /// Computes the closest window obstacle in each of the four cardinal directions
+        /// (left, right, top, bottom) relative to the current window, and returns the boundaries
+        /// formed by these obstacles, constrained to the screen frame.
         func computeBoundaries() -> (minX: CGFloat, minY: CGFloat, maxX: CGFloat, maxY: CGFloat) {
             var minX = screenFrame.minX
             var minY = screenFrame.minY

--- a/Loop/Window Management/Window Manipulation/WindowRecords.swift
+++ b/Loop/Window Management/Window Manipulation/WindowRecords.swift
@@ -68,7 +68,7 @@ enum WindowRecords {
             let windowFrame = window.frame
             let adjustedBounds = PaddingConfiguration
                 .getConfiguredPadding(for: screen)
-                .applyToBounds(screen.cgSafeScreenFrame)
+                .applyToBounds(screen.cgSafeScreenFrame, screen: screen)
 
             let proportionalSize = CGRect(
                 x: (windowFrame.minX - adjustedBounds.minX) / adjustedBounds.width,


### PR DESCRIPTION
Adds an defaults write option "Ignore notch". When enabled, the notch height is subtracted from the top padding on notched displays, so the effective distance from the screen's top edge matches non-notch displays.

Users can enable with:
```
defaults write com.MrKai77.Loop ignoreNotch -bool true
```

Reset with: 
```
defaults delete com.MrKai77.Loop ignoreNotch
```

Users with an external menu bar (e.g. SketchyBar) and the system menu bar hidden experience inconsistent top padding between notched and non-notch displays. On a notched MacBook, `NSScreen.visibleFrame` reserves space for the notch (~32pt), and the external bar padding stacks on top of that — resulting in more top gap than on an external monitor.

When "Ignore notch" is enabled, `applyToBounds` subtracts `screen.menubarHeight` from `totalTopPadding` (clamped to 0), compensating for the notch reserve. Backward-compatible: custom `Codable` init defaults `ignoreNotch` to `false` for existing configs.

Fixes #691

## How has this been tested?

Tested on a MacBook Pro (notch) with an external monitor, system menu bar hidden, SketchyBar as external bar with 40px external bar padding configured in Loop.

- [x] External monitor: top padding remains 40px as configured
- [x] `defaults write com.MrKai77.Loop ignoreNotch -bool true`: top padding matches external monitor (40px from screen top)
- [x] `defaults delete com.MrKai77.Loop ignoreNotch`: top padding is 40px + notch height (existing behavior)
- [x] Existing configs without the new field load correctly (defaults to false)

macOS 15, Loop built from develop branch.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in this PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This change was developed with assistance from Claude (Anthropic). The approach (subtracting `screen.menubarHeight` from top padding when the toggle is enabled) was designed collaboratively — the math and edge cases were worked through together, and all code was reviewed, understood, and tested by the contributor on a real notch + external monitor setup.