### PR TITLE
fix: preserve user-defined cycle order when exporting keybinds

### DIFF
--- a/Loop/Migration/Migrator.swift
+++ b/Loop/Migration/Migrator.swift
@@ -219,16 +219,12 @@ private extension Migrator {
 
                 // Handle nested cycle actions if present
                 if var cycle = actions[i]["cycle"] as? [[String: Any]] {
-                    // Sort the cycle actions by direction
-                    cycle.sort { first, second -> Bool in
-                        let firstDir = first["direction"] as? String ?? ""
-                        let secondDir = second["direction"] as? String ?? ""
-                        return firstDir < secondDir
-                    }
+                    // Note: cycle order is intentionally preserved here, as users
+                    // define the order of actions within a cycle and rely on it
+                    // when "Always start cycles from first item" is enabled.
 
-                    // For each action in the cycle
+                    // Sort only the keybind array within each cycle action
                     for j in 0 ..< cycle.count {
-                        // Sort the keybind array in each cycle action
                         if var cycleKeybind = cycle[j]["keybind"] as? [CGKeyCode] {
                             cycleKeybind.sort()
                             cycle[j]["keybind"] = cycleKeybind


### PR DESCRIPTION
## Summary

Exporting and importing keybinds does not maintain order within user-defined Cycles.

## Problem

The `saveKeybinds` function in `Migrator.swift` sorts cycle actions alphabetically by their `direction` field during export:

```swift
cycle.sort { first, second -> Bool in
    let firstDir = first["direction"] as? String ?? ""
    let secondDir = second["direction"] as? String ?? ""
    return firstDir < secondDir
}
```

This destroys the user-defined order of actions within a cycle. When the exported file is imported on another machine, the cycle executes actions in alphabetical order by direction rather than the order the user configured.

## Fix

Removed the sort on the cycle array itself while preserving the keybind sorting within each cycle action (for consistent JSON output). The user-defined cycle order is now maintained through export/import.

## Testing

- Created a cycle with actions in a specific order (e.g., right half → left half → maximize)
- Exported keybinds to JSON
- Verified the JSON preserves the original cycle order
- Imported on a fresh install and confirmed the cycle executes in the correct order