### PR TITLE
✨ Improved snapping on left, right, and bottom edges

### DIFF
--- a/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
+++ b/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
@@ -8,6 +8,58 @@
 import Foundation
 
 extension WindowDirection {
+    private struct EdgeZoneDirections {
+        let nearCorner: WindowDirection   // ~0-1% from start edge
+        let half: WindowDirection         // ~1-6.3% from start edge
+        let third: WindowDirection        // ~6.3-33% from start edge
+        let centerDefault: WindowDirection // 33-67% center zone default
+        let farThird: WindowDirection     // ~6.3-33% from end edge
+        let farHalf: WindowDirection      // ~1-6.3% from end edge
+        let farCorner: WindowDirection    // ~0-1% from end edge
+        /// (third/twoThirds) pairs for cycling in the center zone
+        let cycleNear: (third: WindowDirection, twoThirds: WindowDirection)
+        let cycleFar: (third: WindowDirection, twoThirds: WindowDirection)
+
+        /// Left edge: Y axis, corners are top-left/bottom-left
+        static let leftEdge = EdgeZoneDirections(
+            nearCorner: .topLeftQuarter,
+            half: .topHalf,
+            third: .topThird,
+            centerDefault: .verticalCenterThird,
+            farThird: .bottomThird,
+            farHalf: .bottomHalf,
+            farCorner: .bottomLeftQuarter,
+            cycleNear: (third: .topThird, twoThirds: .topTwoThirds),
+            cycleFar: (third: .bottomThird, twoThirds: .bottomTwoThirds)
+        )
+
+        /// Right edge: Y axis, corners are top-right/bottom-right
+        static let rightEdge = EdgeZoneDirections(
+            nearCorner: .topRightQuarter,
+            half: .topHalf,
+            third: .topThird,
+            centerDefault: .verticalCenterThird,
+            farThird: .bottomThird,
+            farHalf: .bottomHalf,
+            farCorner: .bottomRightQuarter,
+            cycleNear: (third: .topThird, twoThirds: .topTwoThirds),
+            cycleFar: (third: .bottomThird, twoThirds: .bottomTwoThirds)
+        )
+
+        /// Bottom edge: X axis, corners are bottom-left/bottom-right
+        static let bottomEdge = EdgeZoneDirections(
+            nearCorner: .bottomLeftQuarter,
+            half: .leftHalf,
+            third: .leftThird,
+            centerDefault: .horizontalCenterThird,
+            farThird: .rightThird,
+            farHalf: .rightHalf,
+            farCorner: .bottomRightQuarter,
+            cycleNear: (third: .leftThird, twoThirds: .leftTwoThirds),
+            cycleFar: (third: .rightThird, twoThirds: .rightTwoThirds)
+        )
+    }
+
     static func getSnapDirection(
         mouseLocation: CGPoint,
         currentDirection: WindowDirection,
@@ -17,50 +69,82 @@ extension WindowDirection {
         var newDirection: WindowDirection = .noAction
 
         if mouseLocation.x < ignoredFrame.minX {
-            newDirection = WindowDirection.processLeftSnap(mouseLocation, screenFrame)
+            newDirection = WindowDirection.processEdgeSnap(
+                mousePos: mouseLocation.y,
+                axisMax: screenFrame.maxY,
+                axisLength: screenFrame.height,
+                currentDirection: currentDirection,
+                zones: .leftEdge
+            )
         } else if mouseLocation.x > ignoredFrame.maxX {
-            newDirection = WindowDirection.processRightSnap(mouseLocation, screenFrame)
+            newDirection = WindowDirection.processEdgeSnap(
+                mousePos: mouseLocation.y,
+                axisMax: screenFrame.maxY,
+                axisLength: screenFrame.height,
+                currentDirection: currentDirection,
+                zones: .rightEdge
+            )
         } else if mouseLocation.y < ignoredFrame.minY {
             newDirection = WindowDirection.processTopSnap(mouseLocation, screenFrame)
         } else if mouseLocation.y > ignoredFrame.maxY {
-            newDirection = WindowDirection.processBottomSnap(mouseLocation, screenFrame, currentDirection)
+            newDirection = WindowDirection.processEdgeSnap(
+                mousePos: mouseLocation.x,
+                axisMax: screenFrame.maxX,
+                axisLength: screenFrame.width,
+                currentDirection: currentDirection,
+                zones: .bottomEdge
+            )
         }
 
         return newDirection
     }
 
-    private static func processLeftSnap(
-        _ mouseLocation: CGPoint,
-        _ screenFrame: CGRect
+    private static func processEdgeSnap(
+        mousePos: CGFloat,
+        axisMax: CGFloat,
+        axisLength: CGFloat,
+        currentDirection: WindowDirection,
+        zones: EdgeZoneDirections
     ) -> WindowDirection {
-        let mouseY = mouseLocation.y
-        let maxY = screenFrame.maxY
-        let height = screenFrame.height
+        // Near edge ~1% (1/95): corner
+        if mousePos < axisMax - (axisLength * 94 / 95) {
+            return zones.nearCorner
+        }
 
-        if mouseY < maxY - (height * 7 / 8) {
-            return .topLeftQuarter
+        // Near edge ~1%-6.3% (1/95 to 6/95): half
+        if mousePos < axisMax - (axisLength * 89 / 95) {
+            return zones.half
         }
-        if mouseY > maxY - (height * 1 / 8) {
-            return .bottomLeftQuarter
-        }
-        return .leftHalf
-    }
 
-    private static func processRightSnap(
-        _ mouseLocation: CGPoint,
-        _ screenFrame: CGRect
-    ) -> WindowDirection {
-        let mouseY = mouseLocation.y
-        let maxY = screenFrame.maxY
-        let height = screenFrame.height
+        // Near edge 6.3%-33% (6/95 to 1/3): third
+        if mousePos < axisMax - (axisLength * 2 / 3) {
+            return zones.third
+        }
 
-        if mouseY < maxY - (height * 7 / 8) {
-            return .topRightQuarter
+        // Far edge ~1% (1/95): corner
+        if mousePos > axisMax - (axisLength * 1 / 95) {
+            return zones.farCorner
         }
-        if mouseY > maxY - (height * 1 / 8) {
-            return .bottomRightQuarter
+
+        // Far edge ~1%-6.3% (1/95 to 6/95): half
+        if mousePos > axisMax - (axisLength * 6 / 95) {
+            return zones.farHalf
         }
-        return .rightHalf
+
+        // Far edge 6.3%-33% (6/95 to 1/3): third
+        if mousePos > axisMax - (axisLength * 1 / 3) {
+            return zones.farThird
+        }
+
+        // Center zone: default third, cycle to two-thirds
+        if currentDirection == zones.cycleNear.third || currentDirection == zones.cycleNear.twoThirds {
+            return zones.cycleNear.twoThirds
+        }
+        if currentDirection == zones.cycleFar.third || currentDirection == zones.cycleFar.twoThirds {
+            return zones.cycleFar.twoThirds
+        }
+
+        return zones.centerDefault
     }
 
     private static func processTopSnap(
@@ -71,38 +155,12 @@ extension WindowDirection {
         let maxX = screenFrame.maxX
         let width = screenFrame.width
 
+        // Outer 1/5 edges (0-20% and 80-100%): top half
         if mouseX < maxX - (width * 4 / 5) || mouseX > maxX - (width * 1 / 5) {
             return .topHalf
         }
+
+        // Center zone (20-80%): maximize
         return .maximize
-    }
-
-    private static func processBottomSnap(
-        _ mouseLocation: CGPoint,
-        _ screenFrame: CGRect,
-        _ currentDirection: WindowDirection
-    ) -> WindowDirection {
-        var newDirection: WindowDirection
-
-        let mouseX = mouseLocation.x
-        let maxX = screenFrame.maxX
-        let width = screenFrame.width
-
-        if mouseX < maxX - (width * 2 / 3) {
-            newDirection = .leftThird
-        } else if mouseX > maxX - (width * 1 / 3) {
-            newDirection = .rightThird
-        } else {
-            // mouse is within 1/3 and 2/3 of the screen's width
-            newDirection = .bottomHalf
-
-            if currentDirection == .leftThird || currentDirection == .leftTwoThirds {
-                newDirection = .leftTwoThirds
-            } else if currentDirection == .rightThird || currentDirection == .rightTwoThirds {
-                newDirection = .rightTwoThirds
-            }
-        }
-
-        return newDirection
     }
 }

--- a/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
+++ b/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
@@ -206,6 +206,11 @@ extension WindowDirection {
             zones.third, zones.farThird
         ]
         if outerZones.contains(currentDirection) {
+            if mousePos < centerMid - threshold {
+                return zones.cycleNear.twoThirds
+            } else if mousePos > centerMid + threshold {
+                return zones.cycleFar.twoThirds
+            }
             return zones.centerThird
         }
 

--- a/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
+++ b/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
@@ -9,23 +9,42 @@ import Foundation
 
 extension WindowDirection {
     private struct EdgeZoneDirections {
-        let nearCorner: WindowDirection   // ~0-1% from start edge
-        let half: WindowDirection         // ~1-6.3% from start edge
-        let third: WindowDirection        // ~6.3-33% from start edge
-        let centerDefault: WindowDirection // 33-67% center zone default
-        let farThird: WindowDirection     // ~6.3-33% from end edge
-        let farHalf: WindowDirection      // ~1-6.3% from end edge
-        let farCorner: WindowDirection    // ~0-1% from end edge
-        /// (third/twoThirds) pairs for cycling in the center zone
+        /// < 1.05% - Extreme start corner (e.g., Top-Left)
+        let nearCorner: WindowDirection
+
+        /// 1.05% - 6.31% - Start half (e.g., Top Half)
+        let half: WindowDirection
+
+        /// 6.31% - 33.33% - Start third (e.g., Top Third)
+        let third: WindowDirection
+
+        /// 33.33% - 66.67% - Default center zone action (e.g., Full Edge Half)
+        let edgeHalf: WindowDirection
+
+        /// 33.33% - 66.67% - Center zone action when coming from a side zone
+        let centerThird: WindowDirection
+
+        /// 66.67% - 93.68% - End third (e.g., Bottom Third)
+        let farThird: WindowDirection
+
+        /// 93.68% - 98.95% - End half (e.g., Bottom Half)
+        let farHalf: WindowDirection
+
+        /// > 98.95% - Extreme end corner (e.g., Bottom-Left)
+        let farCorner: WindowDirection
+
+        /// Center zone actions available when cycling from `nearCorner`
         let cycleNear: (third: WindowDirection, twoThirds: WindowDirection)
+
+        /// Center zone actions available when cycling from `farCorner`
         let cycleFar: (third: WindowDirection, twoThirds: WindowDirection)
 
-        /// Left edge: Y axis, corners are top-left/bottom-left
         static let leftEdge = EdgeZoneDirections(
             nearCorner: .topLeftQuarter,
             half: .topHalf,
             third: .topThird,
-            centerDefault: .verticalCenterThird,
+            edgeHalf: .leftHalf,
+            centerThird: .verticalCenterThird,
             farThird: .bottomThird,
             farHalf: .bottomHalf,
             farCorner: .bottomLeftQuarter,
@@ -33,12 +52,12 @@ extension WindowDirection {
             cycleFar: (third: .bottomThird, twoThirds: .bottomTwoThirds)
         )
 
-        /// Right edge: Y axis, corners are top-right/bottom-right
         static let rightEdge = EdgeZoneDirections(
             nearCorner: .topRightQuarter,
             half: .topHalf,
             third: .topThird,
-            centerDefault: .verticalCenterThird,
+            edgeHalf: .rightHalf,
+            centerThird: .verticalCenterThird,
             farThird: .bottomThird,
             farHalf: .bottomHalf,
             farCorner: .bottomRightQuarter,
@@ -46,12 +65,12 @@ extension WindowDirection {
             cycleFar: (third: .bottomThird, twoThirds: .bottomTwoThirds)
         )
 
-        /// Bottom edge: X axis, corners are bottom-left/bottom-right
         static let bottomEdge = EdgeZoneDirections(
             nearCorner: .bottomLeftQuarter,
             half: .leftHalf,
             third: .leftThird,
-            centerDefault: .horizontalCenterThird,
+            edgeHalf: .bottomHalf,
+            centerThird: .horizontalCenterThird,
             farThird: .rightThird,
             farHalf: .rightHalf,
             farCorner: .bottomRightQuarter,
@@ -66,28 +85,32 @@ extension WindowDirection {
         screenFrame: CGRect,
         ignoredFrame: CGRect
     ) -> WindowDirection {
-        var newDirection: WindowDirection = .noAction
-
         if mouseLocation.x < ignoredFrame.minX {
-            newDirection = WindowDirection.processEdgeSnap(
+            return WindowDirection.processEdgeSnap(
                 mousePos: mouseLocation.y,
                 axisMax: screenFrame.maxY,
                 axisLength: screenFrame.height,
                 currentDirection: currentDirection,
                 zones: .leftEdge
             )
-        } else if mouseLocation.x > ignoredFrame.maxX {
-            newDirection = WindowDirection.processEdgeSnap(
+        }
+
+        if mouseLocation.x > ignoredFrame.maxX {
+            return WindowDirection.processEdgeSnap(
                 mousePos: mouseLocation.y,
                 axisMax: screenFrame.maxY,
                 axisLength: screenFrame.height,
                 currentDirection: currentDirection,
                 zones: .rightEdge
             )
-        } else if mouseLocation.y < ignoredFrame.minY {
-            newDirection = WindowDirection.processTopSnap(mouseLocation, screenFrame)
-        } else if mouseLocation.y > ignoredFrame.maxY {
-            newDirection = WindowDirection.processEdgeSnap(
+        } 
+        
+        if mouseLocation.y < ignoredFrame.minY {
+            return WindowDirection.processTopSnap(mouseLocation, screenFrame)
+        } 
+        
+        if mouseLocation.y > ignoredFrame.maxY {
+            return WindowDirection.processEdgeSnap(
                 mousePos: mouseLocation.x,
                 axisMax: screenFrame.maxX,
                 axisLength: screenFrame.width,
@@ -96,7 +119,7 @@ extension WindowDirection {
             )
         }
 
-        return newDirection
+        return .noAction
     }
 
     private static func processEdgeSnap(
@@ -136,15 +159,36 @@ extension WindowDirection {
             return zones.farThird
         }
 
-        // Center zone: default third, cycle to two-thirds
-        if currentDirection == zones.cycleNear.third || currentDirection == zones.cycleNear.twoThirds {
+        // Center zone: results are stable once set.
+        // If already showing a center-zone result, keep it.
+        let centerResults: [WindowDirection] = [
+            zones.edgeHalf,
+            zones.cycleNear.twoThirds, zones.cycleFar.twoThirds,
+            zones.centerThird
+        ]
+        if centerResults.contains(currentDirection) {
+            return currentDirection
+        }
+
+        // From a corner → twoThirds
+        if currentDirection == zones.nearCorner {
             return zones.cycleNear.twoThirds
         }
-        if currentDirection == zones.cycleFar.third || currentDirection == zones.cycleFar.twoThirds {
+        if currentDirection == zones.farCorner {
             return zones.cycleFar.twoThirds
         }
 
-        return zones.centerDefault
+        // From a half/third outer zone → centerThird
+        let outerZones: [WindowDirection] = [
+            zones.half, zones.farHalf,
+            zones.third, zones.farThird
+        ]
+        if outerZones.contains(currentDirection) {
+            return zones.centerThird
+        }
+
+        // Default: the edge's own half
+        return zones.edgeHalf
     }
 
     private static func processTopSnap(

--- a/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
+++ b/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
@@ -161,12 +161,34 @@ extension WindowDirection {
 
         // Center zone: results are stable once set.
         // If already showing a center-zone result, keep it.
-        let centerResults: [WindowDirection] = [
-            zones.edgeHalf,
-            zones.cycleNear.twoThirds, zones.cycleFar.twoThirds,
-            zones.centerThird
-        ]
-        if centerResults.contains(currentDirection) {
+        // Center zone results with sticky or transition logic
+        if currentDirection == zones.edgeHalf {
+            return currentDirection
+        }
+
+        let centerMid = axisMax - (axisLength * 0.5)
+        let threshold = axisLength * 0.05 // 5% of screen dimension
+
+        if currentDirection == zones.centerThird {
+            if mousePos < centerMid - threshold {
+                return zones.cycleNear.twoThirds
+            } else if mousePos > centerMid + threshold {
+                return zones.cycleFar.twoThirds
+            }
+            return currentDirection
+        }
+
+        if currentDirection == zones.cycleNear.twoThirds {
+            if mousePos > centerMid {
+                return zones.centerThird
+            }
+            return currentDirection
+        }
+
+        if currentDirection == zones.cycleFar.twoThirds {
+            if mousePos < centerMid {
+                return zones.centerThird
+            }
             return currentDirection
         }
 

--- a/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
+++ b/Loop/Window Management/Window Action/WindowDirection+Snapping.swift
@@ -103,12 +103,12 @@ extension WindowDirection {
                 currentDirection: currentDirection,
                 zones: .rightEdge
             )
-        } 
-        
+        }
+
         if mouseLocation.y < ignoredFrame.minY {
             return WindowDirection.processTopSnap(mouseLocation, screenFrame)
-        } 
-        
+        }
+
         if mouseLocation.y > ignoredFrame.maxY {
             return WindowDirection.processEdgeSnap(
                 mousePos: mouseLocation.x,


### PR DESCRIPTION
## Description

Adds Rectangle-style vertical snapping to `WindowDirection+Snapping.swift`. When dragging a window to the left, right, or bottom screen edge, snap zones now include corners, halves, thirds, center thirds, and two-thirds cycling — providing full coverage of all tiling options via drag-to-snap.

Fixes #1066

### Changes

- Left/Right edges now have 7 vertical zones (by mouse Y position): corner quarters (~1%), top/bottom half (~1–6.3%), top/bottom vertical third (6.3–33%), and a center zone that defaults to `verticalCenterThird` with `topTwoThirds`/`bottomTwoThirds` cycling
- Bottom edge now has the same 7-zone layout applied horizontally: corner quarters, left/right half, left/right third, and horizontalCenterThird with leftTwoThirds/rightTwoThirds cycling
- Consolidated `processLeftSnap`, `processRightSnap`, and `processBottomSnap` into a single generic processEdgeSnap function with an `EdgeZoneDirections` configuration struct, eliminating code duplication
- Zone thresholds for corners (1/95) and halves (6/95) are derived from measurements of Rectangle's snapping behavior

## How has this been tested?

macOS (Sequoia 15.3.2)

Tested drag-to-snap on all three edges (left, right, bottom), verifying each of the 7 zones returns the correct `WindowDirection`:

- [x] Verified two-thirds cycling works when dragging from a third zone into the center zone
- [x] Left edge: corner quarters, `topHalf`, `topThird`, `verticalCenterThird`, `bottomThird`, `bottomHalf` zones
- [x] Right edge: corner quarters, `topHalf`, `topThird`, `verticalCenterThird`, `bottomThird`, `bottomHalf` zones
- [x] Bottom edge: corner quarters, `leftHalf`, `leftThird`, `horizontalCenterThird`, `rightThird`, `rightHalf` zones
- [x] Center zone two-thirds cycling (e.g. `topThird` → drag to center → `topTwoThirds`)
- [x] Top edge behavior unchanged (`topHalf` at edges, `maximize` in center)

<details><summary><h2>Video Demos</h2></summary>

https://github.com/user-attachments/assets/a782ba3a-a3c4-4b7e-99c1-3b3f2ecd1ab8

https://github.com/user-attachments/assets/8575982c-83f9-4ebe-8452-d9841ce95ba0

</details>

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in this PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used [Claude Opus 4.6 (Thinking)](https://www.anthropic.com/claude/opus) to help develop the snapping zone logic, zone thresholds, `EdgeZoneDirections` consolidation pattern, and code structure. All changes were reviewed and tested manually.