### PR TITLE
✨ Use NSDockTilePlugIn to customize icon

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -124,5 +124,5 @@
 --xcode-indentation disabled
 --xctest-symbols 
 --yoda-swap always
---disable genericExtensions,redundantProperty,simplifyGenericConstraints,wrapMultilineStatementBraces,wrapPropertyBodies
+--disable genericExtensions,redundantVariable,simplifyGenericConstraints,wrapMultilineStatementBraces,wrapPropertyBodies
 --enable isEmpty

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		2A28492B2F22B4B700F6CE42 /* Scribe in Frameworks */ = {isa = PBXBuildFile; productRef = 2A28492A2F22B4B700F6CE42 /* Scribe */; };
 		2A28B6292EE5050C00A1E26B /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 2A28B6282EE5050C00A1E26B /* Defaults */; };
 		2A28B62C2EE5057C00A1E26B /* Luminare in Frameworks */ = {isa = PBXBuildFile; productRef = 2A28B62B2EE5057C00A1E26B /* Luminare */; };
+		2A86890D2F80968A005B521B /* LoopDockTile.plugin in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2A8689072F809625005B521B /* LoopDockTile.plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		2AE091C72F81A22800EF6149 /* Scribe in Frameworks */ = {isa = PBXBuildFile; productRef = 2AE091C62F81A22800EF6149 /* Scribe */; };
 		2AF9238E2F540B1300F467FD /* Scribe in Frameworks */ = {isa = PBXBuildFile; productRef = 2AF9238D2F540B1300F467FD /* Scribe */; };
 		2AF923902F540B2200F467FD /* Scribe in Frameworks */ = {isa = PBXBuildFile; productRef = 2AF9238F2F540B2200F467FD /* Scribe */; };
 		3ED0A7B92F21DF6800A58629 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 3ED0A7B82F21DF6800A58629 /* ZIPFoundation */; };
@@ -18,6 +20,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2A8689102F809800005B521B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A8E59C2D297F5E9A0064D4BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2A8689062F809625005B521B;
+			remoteInfo = LoopDockTile;
+		};
 		B1AA00512F30000100AABBCC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A8E59C2D297F5E9A0064D4BA /* Project object */;
@@ -28,6 +37,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		2A86890C2F80967B005B521B /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				2A86890D2F80968A005B521B /* LoopDockTile.plugin in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B1AA00612F30000100AABBCC /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -41,6 +60,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2A8689072F809625005B521B /* LoopDockTile.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopDockTile.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		A848130C2BD1A8D100B02E93 /* .github */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .github; sourceTree = "<group>"; };
 		A86AFD7529888B29008F4892 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A883642E298B7288005D6C19 /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
@@ -90,11 +110,20 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		2A6A87F02F4D20D2004E995D /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2A6A87F22F4D20F4004E995D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
+		2A86890E2F809700005B521B /* LoopDockTile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = LoopDockTile; sourceTree = "<group>"; };
 		A8C751AC2D7BA98600B58784 /* Loop */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8C751FF2D7BA98600B58784 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Loop; sourceTree = "<group>"; };
 		B1AA00022F30000100AABBCC /* LoopUpdaterHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2A5DD5CC2F5D270C0077AB3C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LoopUpdaterHelper; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2A8689042F809625005B521B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2AE091C72F81A22800EF6149 /* Scribe in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A8E59C32297F5E9A0064D4BA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -138,6 +167,7 @@
 				A894B0C52C4B31AA00B4CE6F /* CONTRIBUTING.md */,
 				A8C751AC2D7BA98600B58784 /* Loop */,
 				B1AA00022F30000100AABBCC /* LoopUpdaterHelper */,
+				2A86890E2F809700005B521B /* LoopDockTile */,
 				A8E59C36297F5E9A0064D4BA /* Products */,
 				A883642D298B7288005D6C19 /* Frameworks */,
 				2A6A87F02F4D20D2004E995D /* Shared */,
@@ -149,6 +179,7 @@
 			children = (
 				A8E59C35297F5E9A0064D4BA /* Loop.app */,
 				B1AA00012F30000100AABBCC /* LoopUpdaterHelper */,
+				2A8689072F809625005B521B /* LoopDockTile.plugin */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -156,6 +187,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		2A8689062F809625005B521B /* LoopDockTile */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2A8689082F809625005B521B /* Build configuration list for PBXNativeTarget "LoopDockTile" */;
+			buildPhases = (
+				2A8689032F809625005B521B /* Sources */,
+				2A8689042F809625005B521B /* Frameworks */,
+				2A8689052F809625005B521B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				2A86890E2F809700005B521B /* LoopDockTile */,
+			);
+			name = LoopDockTile;
+			packageProductDependencies = (
+				2AE091C62F81A22800EF6149 /* Scribe */,
+			);
+			productName = LoopDockTile;
+			productReference = 2A8689072F809625005B521B /* LoopDockTile.plugin */;
+			productType = "com.apple.product-type.bundle";
+		};
 		A8E59C34297F5E9A0064D4BA /* Loop */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A8E59C44297F5E9B0064D4BA /* Build configuration list for PBXNativeTarget "Loop" */;
@@ -163,12 +217,14 @@
 				A8E59C31297F5E9A0064D4BA /* Sources */,
 				A8E59C32297F5E9A0064D4BA /* Frameworks */,
 				B1AA00612F30000100AABBCC /* CopyFiles */,
+				2A86890C2F80967B005B521B /* CopyFiles */,
 				A8E59C33297F5E9A0064D4BA /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				B1AA00712F30000100AABBCC /* PBXTargetDependency */,
+				2A8689112F809800005B521B /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				2A6A87F02F4D20D2004E995D /* Shared */,
@@ -219,6 +275,9 @@
 				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
+					2A8689062F809625005B521B = {
+						CreatedOnToolsVersion = 26.4;
+					};
 					A8E59C34297F5E9A0064D4BA = {
 						CreatedOnToolsVersion = 14.2;
 					};
@@ -260,11 +319,19 @@
 			targets = (
 				A8E59C34297F5E9A0064D4BA /* Loop */,
 				B1AA00112F30000100AABBCC /* LoopUpdaterHelper */,
+				2A8689062F809625005B521B /* LoopDockTile */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2A8689052F809625005B521B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A8E59C33297F5E9A0064D4BA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -282,6 +349,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2A8689032F809625005B521B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A8E59C31297F5E9A0064D4BA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -299,6 +373,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2A8689112F809800005B521B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2A8689062F809625005B521B /* LoopDockTile */;
+			targetProxy = 2A8689102F809800005B521B /* PBXContainerItemProxy */;
+		};
 		B1AA00712F30000100AABBCC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B1AA00112F30000100AABBCC /* LoopUpdaterHelper */;
@@ -307,6 +386,75 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2A8689092F809625005B521B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5F967GYF84;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MrKai77.Loop.DockTile;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Debug;
+		};
+		2A86890A2F809625005B521B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5F967GYF84;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MrKai77.Loop.DockTile;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Release;
+		};
+		2A86890B2F809625005B521B /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5F967GYF84;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MrKai77.Loop.DockTile;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Development;
+		};
 		2AC87FA52F09E3A600082F90 /* Development */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = A8C751AC2D7BA98600B58784 /* Loop */;
@@ -719,6 +867,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2A8689082F809625005B521B /* Build configuration list for PBXNativeTarget "LoopDockTile" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2A8689092F809625005B521B /* Debug */,
+				2A86890A2F809625005B521B /* Release */,
+				2A86890B2F809625005B521B /* Development */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A8E59C30297F5E9A0064D4BA /* Build configuration list for PBXProject "Loop" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -800,6 +958,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2A28B62A2EE5057C00A1E26B /* XCRemoteSwiftPackageReference "luminare" */;
 			productName = Luminare;
+		};
+		2AE091C62F81A22800EF6149 /* Scribe */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2AF9238C2F540B1300F467FD /* XCRemoteSwiftPackageReference "Scribe" */;
+			productName = Scribe;
 		};
 		2AF9238D2F540B1300F467FD /* Scribe */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Loop/Extensions/NSScreen+Extensions.swift
+++ b/Loop/Extensions/NSScreen+Extensions.swift
@@ -33,9 +33,9 @@ extension NSScreen {
         // excluding points on the maxX/maxY edges. So we cannot use frame.contains(_:)
         return screens.first {
             mouseLocation.x >= $0.frame.minX &&
-            mouseLocation.x <= $0.frame.maxX &&
-            mouseLocation.y >= $0.frame.minY &&
-            mouseLocation.y <= $0.frame.maxY
+                mouseLocation.x <= $0.frame.maxX &&
+                mouseLocation.y >= $0.frame.minY &&
+                mouseLocation.y <= $0.frame.maxY
         }
     }
 

--- a/Loop/Icon/Icon.swift
+++ b/Loop/Icon/Icon.swift
@@ -29,6 +29,10 @@ struct Icon: Hashable, LuminareSelectionData {
     var unlockTime: Int
     var unlockMessage: String?
 
+    var isDefault: Bool {
+        assetName == Bundle.main.infoDictionary?["CFBundleIconName"] as? String
+    }
+
     var isSelectable: Bool {
         IconManager.returnUnlockedIcons().contains(self)
     }
@@ -50,8 +54,6 @@ struct Icon: Hashable, LuminareSelectionData {
             .summer,
             .master
         ]
-
-        static let `default` = Icon.classic
     #else
         static let all: [Icon] = [
             .developer,
@@ -69,8 +71,6 @@ struct Icon: Hashable, LuminareSelectionData {
             .summer,
             .master
         ]
-
-        static let `default` = Icon.developer
     #endif
 }
 

--- a/Loop/Icon/IconManager.swift
+++ b/Loop/Icon/IconManager.swift
@@ -42,17 +42,30 @@ enum IconManager {
             return
         }
 
+        let isDefault = IconManager.currentAppIcon.isDefault
+
+        // Notify the dock tile plugin first so it updates immediately
+        DistributedNotificationCenter.default().post(
+            name: .init("com.MrKai77.Loop.iconChanged"),
+            object: nil,
+            userInfo: [
+                "iconName": iconName,
+                "isDefault": isDefault
+            ]
+        )
+
         #if !DEBUG
             // Changing the app's actual icon on a developer build can cause Xcode to have incremental codesign issues.
             // To prevent this, we only change the icon on release builds.
-            NSWorkspace.shared.setIcon(image, forFile: Bundle.main.bundlePath, options: [])
-        #endif
+            if isDefault {
+                NSWorkspace.shared.setIcon(nil, forFile: Bundle.main.bundlePath, options: [])
+            } else {
+                NSWorkspace.shared.setIcon(image, forFile: Bundle.main.bundlePath, options: [])
+            }
 
-        if Defaults[.currentIcon] == Icon.default.assetName {
-            NSApp.applicationIconImage = nil
-        } else {
-            NSApp.applicationIconImage = image
-        }
+            deleteDockIconCache()
+            SkyLightToolBelt.refreshIconAppearanceCache()
+        #endif
 
         log.info("Set app icon to: \(iconName)")
     }
@@ -84,6 +97,21 @@ enum IconManager {
             content.categoryIdentifier = "icon_unlocked"
 
             AppDelegate.sendNotification(content)
+        }
+    }
+
+    /// Best-effort deletion of the Dock's icon cache file, forcing it to rebuild on next access.
+    private static func deleteDockIconCache() {
+        // The cache lives in the per-user cache dir (/C/), sibling to the temp dir (/T/)
+        let cacheURL = FileManager.default.temporaryDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("C/com.apple.dock.iconcache")
+
+        do {
+            try FileManager.default.removeItem(at: cacheURL)
+            log.debug("Deleted dock icon cache")
+        } catch {
+            log.debug("Failed to delete dock icon cache: \(error.localizedDescription)")
         }
     }
 

--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -13,5 +13,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSDockTilePlugIn</key>
+	<string>LoopDockTile.plugin</string>
 </dict>
 </plist>

--- a/Loop/Private APIs/SkyLightToolBelt.swift
+++ b/Loop/Private APIs/SkyLightToolBelt.swift
@@ -190,6 +190,32 @@ enum SkyLightToolBelt {
         return nil
     }
 
+    /// Forces the system to re-resolve icon appearance variants by flushing the Dock's icon cache.
+    /// Re-saves the current `SLSIconAppearanceConfiguration`, causing the Dock to re-read the
+    /// bundle's `.icon` file (which supports light/dark/clear variants).
+    /// https://www.granola.ai/blog/so-you-think-its-easy-to-change-an-app-icon
+    static func refreshIconAppearanceCache() {
+        guard let cls = NSClassFromString("SLSIconAppearanceConfiguration") as? NSObject.Type else {
+            log.error("SLSIconAppearanceConfiguration class not found")
+            return
+        }
+
+        let fetchSelector = NSSelectorFromString("fetchCurrentIconAppearanceConfiguration")
+        guard cls.responds(to: fetchSelector),
+              let config = cls.perform(fetchSelector)?.takeUnretainedValue() as? NSObject else {
+            log.error("Failed to fetch icon appearance configuration")
+            return
+        }
+
+        let saveSelector = NSSelectorFromString("save")
+        guard config.responds(to: saveSelector) else {
+            log.error("Icon appearance configuration does not respond to save")
+            return
+        }
+
+        config.perform(saveSelector)
+    }
+
     /// Checks if the current window in a `SLSWindowIterator` is valid for Loop to use.
     /// - Parameter iterator: The `SLSWindowIterator` object
     /// - Returns: Whether this window is valid.

--- a/Loop/Resources/AppIcon-Developer.icon/icon.json
+++ b/Loop/Resources/AppIcon-Developer.icon/icon.json
@@ -2,8 +2,8 @@
   "color-space-for-untagged-svg-colors" : "display-p3",
   "fill" : {
     "linear-gradient" : [
-      "display-p3:0.12549,0.61961,0.90588,1.00000",
-      "srgb:0.09804,0.39216,0.70196,1.00000"
+      "display-p3:0.34497,0.74512,0.96094,1.00000",
+      "display-p3:0.20801,0.42456,0.94580,1.00000"
     ]
   },
   "groups" : [

--- a/Loop/Settings Window/Theming/IconConfiguration.swift
+++ b/Loop/Settings Window/Theming/IconConfiguration.swift
@@ -163,7 +163,7 @@ struct IconVew: View {
     @State private var loopsLeft: Int = -1
 
     private var showLiquidGlassIndicator: Bool {
-        if #available(macOS 26.0, *), icon == Icon.default {
+        if #available(macOS 26.0, *), icon.isDefault {
             true
         } else {
             false

--- a/Loop/Updater/UpdateDownloader.swift
+++ b/Loop/Updater/UpdateDownloader.swift
@@ -308,7 +308,7 @@ private enum FileValidator {
 
 // MARK: - DownloadError
 
-enum DownloadError: LocalizedError, Sendable {
+enum DownloadError: LocalizedError {
     case downloadInProgress
     case invalidURL(String)
     case environmentError(String)

--- a/Loop/Updater/UpdateInstaller.swift
+++ b/Loop/Updater/UpdateInstaller.swift
@@ -12,7 +12,7 @@ import Security
 
 @Loggable
 actor UpdateInstaller {
-    enum InstallationPermissionState: Sendable {
+    enum InstallationPermissionState {
         case writable
         case needsElevation(reason: String)
         case notWritableNoElevationPossible(reason: String)
@@ -1179,7 +1179,7 @@ actor UpdateInstaller {
 
 // MARK: - AppLocation
 
-enum AppLocation: CustomStringConvertible, Sendable {
+enum AppLocation: CustomStringConvertible {
     case systemApplications
     case userApplications
     case other(String)

--- a/Loop/Updater/UpdaterAuthorizationCoordinator.swift
+++ b/Loop/Updater/UpdaterAuthorizationCoordinator.swift
@@ -12,7 +12,7 @@ import ServiceManagement
 
 @Loggable
 final class UpdaterAuthorizationCoordinator {
-    enum PrivilegedHelperReadiness: Sendable {
+    enum PrivilegedHelperReadiness {
         case available
         case unavailable(reason: String)
     }

--- a/Loop/Updater/UpdaterModels.swift
+++ b/Loop/Updater/UpdaterModels.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - UpdateChannel
 
-enum UpdateChannel: String, Sendable, CaseIterable {
+enum UpdateChannel: String, CaseIterable {
     case stable
     case development
 
@@ -37,7 +37,7 @@ enum UpdateChannel: String, Sendable, CaseIterable {
 
 // MARK: - UpdateManifest
 
-struct UpdateManifest: Sendable {
+struct UpdateManifest {
     let version: String
     let buildNumber: Int
     let downloadUrl: String
@@ -48,25 +48,25 @@ struct UpdateManifest: Sendable {
     let publishedAt: Date
     let size: Int64
 
-    struct ReleaseNotes: Sendable {
+    struct ReleaseNotes {
         let title: String
         let body: String
     }
 
-    struct Compatibility: Sendable {
+    struct Compatibility {
         let minimumOS: OperatingSystemVersion?
         let maximumOS: OperatingSystemVersion?
         let supportedArchitectures: [SystemInfo.Architecture]
     }
 
-    struct Checksums: Sendable {
+    struct Checksums {
         let zip: String
     }
 }
 
 // MARK: - UpdateProgress
 
-struct UpdateProgress: Sendable {
+struct UpdateProgress {
     let phase: UpdatePhase
     let percentage: Double
     let bytesDownloaded: Int64
@@ -74,7 +74,7 @@ struct UpdateProgress: Sendable {
     let estimatedTimeRemaining: TimeInterval?
     let downloadSpeed: Double?
 
-    enum UpdatePhase: String, Sendable {
+    enum UpdatePhase: String {
         case checking, downloading, extracting, verifying, installing, cleaning, completed, failed
     }
 
@@ -97,7 +97,7 @@ struct UpdateProgress: Sendable {
 
 // MARK: - UpdateError
 
-enum UpdateError: LocalizedError, Sendable {
+enum UpdateError: LocalizedError {
     case network(Error)
     case invalidManifest(String? = nil)
     case checksumMismatch

--- a/LoopDockTile/LoopDockTilePlugin.swift
+++ b/LoopDockTile/LoopDockTilePlugin.swift
@@ -1,0 +1,80 @@
+//
+//  LoopDockTilePlugin.swift
+//  LoopDockTile
+//
+//  Created by Kai Azim on 2026-04-03.
+//
+
+import AppKit
+import Scribe
+
+@Loggable
+final class LoopDockTilePlugin: NSObject, NSDockTilePlugIn {
+    private var dockTile: NSDockTile?
+    private var notificationObserver: Any?
+    private let appBundleID = "com.MrKai77.Loop"
+    private let notificationName = Notification.Name("com.MrKai77.Loop.iconChanged")
+    private lazy var appDefaults = UserDefaults(suiteName: appBundleID)
+
+    /// The host app bundle, resolved from the plugin's location inside Contents/PlugIns/
+    private lazy var hostAppBundle: Bundle? = {
+        let pluginBundle = Bundle(for: type(of: self))
+        let plugInsURL = pluginBundle.bundleURL.deletingLastPathComponent()
+        let contentsURL = plugInsURL.deletingLastPathComponent()
+        let appURL = contentsURL.deletingLastPathComponent()
+        return Bundle(url: appURL)
+    }()
+
+    func setDockTile(_ dockTile: NSDockTile?) {
+        self.dockTile = dockTile
+
+        notificationObserver = DistributedNotificationCenter.default().addObserver(
+            forName: notificationName,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let iconName = notification.userInfo?["iconName"] as? String
+            let isDefault = notification.userInfo?["isDefault"] as? Bool
+            self?.updateDockTile(iconName: iconName, isDefault: isDefault)
+        }
+
+        // On initial load, we don't have notification userInfo, so read from preferences
+        updateDockTile(iconName: nil, isDefault: nil)
+    }
+
+    private func updateDockTile(iconName: String?, isDefault: Bool?) {
+        guard let dockTile else { return }
+
+        // Fall back to reading preferences if values aren't sent through notification
+        let resolvedIsDefault: Bool
+        if let isDefault {
+            resolvedIsDefault = isDefault
+        } else {
+            let storedIcon = appDefaults?.string(forKey: "currentIcon")
+            let bundleAppIcon = hostAppBundle?.infoDictionary?["CFBundleIconName"] as? String
+            resolvedIsDefault = storedIcon == nil || storedIcon == bundleAppIcon
+        }
+
+        if resolvedIsDefault {
+            dockTile.contentView = nil
+            log.info("Cleared dock tile content view")
+        } else if let iconName = iconName ?? appDefaults?.string(forKey: "currentIcon"),
+                  let image = hostAppBundle?.image(forResource: iconName) {
+            let imageView = NSImageView(image: image)
+            imageView.imageScaling = .scaleProportionallyUpOrDown
+            imageView.wantsLayer = true
+            dockTile.contentView = imageView
+            log.info("Set image as dock tile content view")
+        } else {
+            log.error("Failed to load icon image")
+        }
+
+        dockTile.display()
+    }
+
+    deinit {
+        if let observer = notificationObserver {
+            DistributedNotificationCenter.default().removeObserver(observer)
+        }
+    }
+}


### PR DESCRIPTION
Adds a `NSDockTilePlugIn` to manage Loop's Dock icon, replacing the previous approach of only setting `NSApp.applicationIconImage`. This is the more "normal" way for an app to change its dock icon, and matches the implementation of other apps such as Arc.

### Changes

- `IconManager` updates: When the icon changes, a distributed notification is posted so the dock plugin can react immediately. After setting the icon, the Dock's icon cache is deleted (best-effort) and `SLSIconAppearanceConfiguration` is re-saved to force the Dock to re-read the bundle's `.icon` file ([reference!](https://www.granola.ai/blog/so-you-think-its-easy-to-change-an-app-icon))
- New `Icon.isDefault` computed property replaces the old `Icon.default` static with a cleaner check against `CFBundleIconName`.
- The developer icon gradient has also been updated to match Apple's own apps (Xcode, Simulator) more closely.