### PR TITLE
✨ Add option to restrict "Resize window under cursor" to mouse triggers

### DIFF
--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -37,7 +37,7 @@ final class LoopManager {
         windowActionCache: windowActionCache,
         openCallback: { [weak self] action in
             Task {
-                await self?.openLoop(startingAction: action)
+                await self?.openLoop(startingAction: action, triggerSource: .keyboard)
             }
         },
         closeCallback: { [weak self] forceClose in
@@ -53,7 +53,7 @@ final class LoopManager {
     private(set) lazy var middleClickTrigger = MiddleClickTrigger(
         openCallback: { [weak self] action in
             Task {
-                await self?.openLoop(startingAction: action)
+                await self?.openLoop(startingAction: action, triggerSource: .mouse)
             }
         },
         closeCallback: { [weak self] forceClose in
@@ -108,7 +108,7 @@ final class LoopManager {
 // MARK: - Opening/Closing Loop
 
 extension LoopManager {
-    private func openLoop(startingAction: WindowAction) async {
+    private func openLoop(startingAction: WindowAction, triggerSource: TriggerSource = .keyboard) async {
         guard AccessibilityManager.shared.isGranted else {
             return
         }
@@ -125,7 +125,7 @@ extension LoopManager {
             return
         }
 
-        let window = WindowUtility.userDefinedTargetWindow()
+        let window = WindowUtility.userDefinedTargetWindow(triggerSource: triggerSource)
 
         guard
             window?.isAppExcluded != true,

--- a/Loop/Core/URLCommandHandler.swift
+++ b/Loop/Core/URLCommandHandler.swift
@@ -484,7 +484,7 @@ final class URLCommandHandler {
 
         if let keybind = keybinds.first(where: { $0.name?.lowercased() == keybindName.lowercased() }) {
             writeToOutput("[URLHandler] Executing keybind: \(keybind.name ?? "unnamed")")
-            if let window = WindowUtility.userDefinedTargetWindow(),
+            if let window = WindowUtility.userDefinedTargetWindow(triggerSource: .urlCommand),
                let screen = NSScreen.main {
                 Task {
                     _ = try await WindowActionEngine.shared.apply(
@@ -610,7 +610,7 @@ final class URLCommandHandler {
     /// - Parameter visibleWindows: Array of visible windows to choose from
     /// - Returns: The most appropriate window or nil if none found
     private func findTargetWindow(from visibleWindows: [Window]) -> Window? {
-        if let targetWindow = WindowUtility.userDefinedTargetWindow() {
+        if let targetWindow = WindowUtility.userDefinedTargetWindow(triggerSource: .urlCommand) {
             writeToOutput("[URLHandler] Using WindowEngine.getTargetWindow(): \(targetWindow.title ?? "unknown")")
             return targetWindow
         }

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -52,6 +52,7 @@ extension Defaults.Keys {
     static let useScreenWithCursor = Key<Bool>("useScreenWithCursor", default: true, iCloud: true)
     static let moveCursorWithWindow = Key<Bool>("moveCursorWithWindow", default: false, iCloud: true)
     static let resizeWindowUnderCursor = Key<Bool>("resizeWindowUnderCursor", default: false, iCloud: true)
+    static let resizeWindowUnderCursorOnlyOnMouseTrigger = Key<Bool>("resizeWindowUnderCursorOnlyOnMouseTrigger", default: false, iCloud: true)
     static let focusWindowOnResize = Key<Bool>("focusWindowOnResize", default: true, iCloud: true)
     static let respectStageManager = Key<Bool>("respectStageManager", default: true, iCloud: true)
     static let stageStripSize = Key<CGFloat>("stageStripSize", default: 150, iCloud: true)

--- a/Loop/Settings Window/Settings/Behavior/BehaviorConfiguration.swift
+++ b/Loop/Settings Window/Settings/Behavior/BehaviorConfiguration.swift
@@ -23,6 +23,7 @@ struct BehaviorConfigurationView: View {
     @Default(.useScreenWithCursor) var useScreenWithCursor
     @Default(.moveCursorWithWindow) var moveCursorWithWindow
     @Default(.resizeWindowUnderCursor) var resizeWindowUnderCursor
+    @Default(.resizeWindowUnderCursorOnlyOnMouseTrigger) var resizeWindowUnderCursorOnlyOnMouseTrigger
     @Default(.focusWindowOnResize) var focusWindowOnResize
     @Default(.respectStageManager) var respectStageManager
     @Default(.stageStripSize) var stageStripSize
@@ -46,6 +47,7 @@ struct BehaviorConfigurationView: View {
             luminareAnimation,
             value: [
                 resizeWindowUnderCursor,
+                resizeWindowUnderCursorOnlyOnMouseTrigger,
                 windowSnapping,
                 respectStageManager
             ]
@@ -100,9 +102,13 @@ struct BehaviorConfigurationView: View {
 
             LuminareToggle("Resize window under cursor", isOn: $resizeWindowUnderCursor)
 
-            // If the system WM is enabled, the window under the cursor requires focus.
-            if resizeWindowUnderCursor, !useSystemWindowManagerWhenAvailable {
-                LuminareToggle("Focus window on resize", isOn: $focusWindowOnResize)
+            if resizeWindowUnderCursor {
+                LuminareToggle("Only with mouse trigger", isOn: $resizeWindowUnderCursorOnlyOnMouseTrigger)
+
+                // If the system WM is enabled, the window under the cursor requires focus.
+                if !useSystemWindowManagerWhenAvailable {
+                    LuminareToggle("Focus window on resize", isOn: $focusWindowOnResize)
+                }
             }
         }
     }

--- a/Loop/Window Management/Window/WindowUtility.swift
+++ b/Loop/Window Management/Window/WindowUtility.swift
@@ -9,20 +9,35 @@ import AppKit
 import Defaults
 import Scribe
 
+/// Describes how Loop was triggered, so window-targeting can adapt.
+enum TriggerSource {
+    case keyboard
+    case mouse
+    case urlCommand
+}
+
 /// This enum is in charge of fetching windows in the user's workspace, which will be used by Loop.
 @Loggable(style: .static)
 enum WindowUtility {
-    /// Get the target window, depending on the user's preferences. This could be the frontmost window, or the window under the cursor.
+    /// Get the target window, depending on the user's preferences and the trigger source.
+    /// When ``resizeWindowUnderCursor`` is enabled together with
+    /// ``resizeWindowUnderCursorOnlyOnMouseTrigger``, keyboard triggers
+    /// will always fall back to the frontmost (focused) window.
+    /// - Parameter triggerSource: How Loop was activated (keyboard, mouse, or URL command).
     /// - Returns: The target window
-    static func userDefinedTargetWindow() -> Window? {
+    static func userDefinedTargetWindow(triggerSource: TriggerSource = .keyboard) -> Window? {
         var result: Window?
 
-        log.info("Getting window at cursor...")
+        let shouldUseWindowUnderCursor = Defaults[.resizeWindowUnderCursor]
+            && (!Defaults[.resizeWindowUnderCursorOnlyOnMouseTrigger] || triggerSource == .mouse)
 
-        if Defaults[.resizeWindowUnderCursor],
-           let mouseLocation = CGEvent.mouseLocation,
-           let window = windowAtPosition(mouseLocation) {
-            result = window
+        if shouldUseWindowUnderCursor {
+            log.info("Getting window at cursor...")
+
+            if let mouseLocation = CGEvent.mouseLocation,
+               let window = windowAtPosition(mouseLocation) {
+                result = window
+            }
         }
 
         if result == nil {


### PR DESCRIPTION
## Summary

Fixes #927

When **Resize window under cursor** is enabled, keyboard shortcuts currently also target the window under the cursor instead of the focused window. This is unintuitive — users expect keybinds to resize the focused window while the cursor-based targeting is only useful with mouse/trackpad interaction.

This PR adds a **"Only with mouse trigger"** sub-toggle (visible when *Resize window under cursor* is enabled) that restricts cursor-based window targeting to mouse/middle-click triggers only. When this option is active, keyboard shortcuts always resize the focused (frontmost) window.

### Changes

- **`TriggerSource` enum** — distinguishes between `keyboard`, `mouse`, and `urlCommand` triggers
- **`WindowUtility.userDefinedTargetWindow(triggerSource:)`** — now accepts a trigger source; when the new setting is on and the trigger is not `.mouse`, falls back to the frontmost window
- **`LoopManager.openLoop(startingAction:triggerSource:)`** — threads the trigger source from `KeybindTrigger` (`.keyboard`) and `MiddleClickTrigger` (`.mouse`)
- **`URLCommandHandler`** — passes `.urlCommand` for URL-based triggers
- **`Defaults+Extensions`** — new `resizeWindowUnderCursorOnlyOnMouseTrigger` boolean preference (defaults to `false`, synced via iCloud)
- **`BehaviorConfiguration`** — the new toggle appears under *Resize window under cursor* in the Cursor settings section

### Behavior matrix

| Setting state | Keyboard trigger | Mouse trigger |
|---|---|---|
| Resize under cursor: **OFF** | Focused window | Focused window |
| Resize under cursor: **ON**, Only mouse: **OFF** | Window under cursor | Window under cursor |
| Resize under cursor: **ON**, Only mouse: **ON** | Focused window | Window under cursor |

## Test plan

- [ ] Enable *Resize window under cursor* in Settings → Behavior → Cursor
- [ ] Verify the new *Only with mouse trigger* toggle appears below it
- [ ] With the new toggle **OFF**: keyboard shortcuts and middle-click both target the window under the cursor (unchanged behavior)
- [ ] With the new toggle **ON**: keyboard shortcuts target the focused window; middle-click still targets the window under the cursor
- [ ] Disable *Resize window under cursor* entirely — verify the sub-toggle disappears and keyboard/mouse both target the focused window