### PR TITLE
✨ Add more `SkyLight` APIs for improved window/screen selection

### DIFF
--- a/Loop/Extensions/NSScreen+Extensions.swift
+++ b/Loop/Extensions/NSScreen+Extensions.swift
@@ -29,6 +29,13 @@ extension NSScreen {
         let mouseLocation = NSEvent.mouseLocation
         let screens = NSScreen.screens
 
+        // Ask SkyLight first so we match WindowServer's tie-breaking at display boundaries.
+        if let primary = screens.first,
+           let displayID = SkyLightToolBelt.bestManagedDisplayID(forCGPoint: mouseLocation.flipY(screen: primary)),
+           let match = screens.first(where: { $0.displayID == displayID }) {
+            return match
+        }
+
         // CGRect.contains uses half-open intervals [minX, maxX) × [minY, maxY),
         // excluding points on the maxX/maxY edges. So we cannot use frame.contains(_:)
         return screens.first {

--- a/Loop/Private APIs/SkyLightSymbolLoader.swift
+++ b/Loop/Private APIs/SkyLightSymbolLoader.swift
@@ -81,6 +81,15 @@ extension SkyLightSymbolLoader {
     @available(macOS 26.0, *)
     static let SLSWindowIteratorGetResolvedCornerRadii: SLSWindowIteratorGetResolvedCornerRadiiFunc? = loadSymbol("SLSWindowIteratorGetResolvedCornerRadii")
 
+
+    /// Returns the UUID (`CFString`) of the display containing `point`, using the same
+    /// tie-breaking WindowServer uses internally. `nil` if no managed display contains it.
+    typealias SLSCopyBestManagedDisplayForPointFunc = @convention(c) (
+        _ cid: SLSConnectionID,
+        _ point: CGPoint
+    ) -> Unmanaged<CFString>?
+    static let SLSCopyBestManagedDisplayForPoint: SLSCopyBestManagedDisplayForPointFunc? = loadSymbol("SLSCopyBestManagedDisplayForPoint")
+
     typealias SLSSetWindowBackgroundBlurRadiusFunc = @convention(c) (_ connection: SLSConnectionID, _ wid: CGWindowID, _ radius: Int) -> OSStatus
     static let SLSSetWindowBackgroundBlurRadius: SLSSetWindowBackgroundBlurRadiusFunc? = loadSymbol("SLSSetWindowBackgroundBlurRadius")
 

--- a/Loop/Private APIs/SkyLightSymbolLoader.swift
+++ b/Loop/Private APIs/SkyLightSymbolLoader.swift
@@ -81,6 +81,17 @@ extension SkyLightSymbolLoader {
     @available(macOS 26.0, *)
     static let SLSWindowIteratorGetResolvedCornerRadii: SLSWindowIteratorGetResolvedCornerRadiiFunc? = loadSymbol("SLSWindowIteratorGetResolvedCornerRadii")
 
+    typealias SLSFindWindowByGeometryFunc = @convention(c) (
+        _ cid: SLSConnectionID,
+        _ filterWindowID: CGWindowID,
+        _ flags: Int32,
+        _ reserved: Int32,
+        _ screenPoint: UnsafePointer<CGPoint>,
+        _ outWindowPoint: UnsafeMutablePointer<CGPoint>,
+        _ outWindowID: UnsafeMutablePointer<CGWindowID>,
+        _ outWindowCID: UnsafeMutablePointer<Int32>
+    ) -> CGError
+    static let SLSFindWindowByGeometry: SLSFindWindowByGeometryFunc? = loadSymbol("SLSFindWindowByGeometry")
 
     /// Returns the UUID (`CFString`) of the display containing `point`, using the same
     /// tie-breaking WindowServer uses internally. `nil` if no managed display contains it.

--- a/Loop/Private APIs/SkyLightToolBelt.swift
+++ b/Loop/Private APIs/SkyLightToolBelt.swift
@@ -158,7 +158,8 @@ enum SkyLightToolBelt {
         var hitWindowID: CGWindowID = 0
         var windowCID: Int32 = 0
 
-        _ = SLSFindWindowByGeometry(cid, 0, 1, 0, &screenPoint, &windowPoint, &hitWindowID, &windowCID)
+        let status = SLSFindWindowByGeometry(cid, 0, 1, 0, &screenPoint, &windowPoint, &hitWindowID, &windowCID)
+        guard status == .success else { return nil }
 
         return hitWindowID != 0 ? hitWindowID : nil
     }

--- a/Loop/Private APIs/SkyLightToolBelt.swift
+++ b/Loop/Private APIs/SkyLightToolBelt.swift
@@ -121,6 +121,27 @@ enum SkyLightToolBelt {
         }
     }
 
+    /// Returns the display ID containing the given point, using the same tie-breaking
+    /// WindowServer uses at display boundaries.
+    /// - Parameter cgPoint: The point in the CoreGraphics coordinate system.
+    /// - Returns: The matching `CGDirectDisplayID`, or `nil` if the point isn't on any
+    ///   managed display.
+    static func bestManagedDisplayID(forCGPoint cgPoint: CGPoint) -> CGDirectDisplayID? {
+        guard let SLSMainConnectionID = SkyLightSymbolLoader.SLSMainConnectionID,
+              let SLSCopyBestManagedDisplayForPoint = SkyLightSymbolLoader.SLSCopyBestManagedDisplayForPoint
+        else {
+            return nil
+        }
+
+        guard let uuidString = SLSCopyBestManagedDisplayForPoint(SLSMainConnectionID(), cgPoint)?.takeRetainedValue(),
+              let uuid = CFUUIDCreateFromString(nil, uuidString)
+        else {
+            return nil
+        }
+
+        let displayID = CGDisplayGetDisplayIDFromUUID(uuid)
+        return displayID != 0 ? displayID : nil
+    }
     /// Captures images for each of the windows that are passed in.
     /// - Parameter windowIDs: The `CGWindowID`s for each of the windows to capture.
     /// - Returns: An array of `CGImage`s for each window, in the same order as the windows that were passed in.

--- a/Loop/Private APIs/SkyLightToolBelt.swift
+++ b/Loop/Private APIs/SkyLightToolBelt.swift
@@ -124,8 +124,7 @@ enum SkyLightToolBelt {
     /// Returns the display ID containing the given point, using the same tie-breaking
     /// WindowServer uses at display boundaries.
     /// - Parameter cgPoint: The point in the CoreGraphics coordinate system.
-    /// - Returns: The matching `CGDirectDisplayID`, or `nil` if the point isn't on any
-    ///   managed display.
+    /// - Returns: The matching `CGDirectDisplayID`, or `nil` if the point isn't on any managed display.
     static func bestManagedDisplayID(forCGPoint cgPoint: CGPoint) -> CGDirectDisplayID? {
         guard let SLSMainConnectionID = SkyLightSymbolLoader.SLSMainConnectionID,
               let SLSCopyBestManagedDisplayForPoint = SkyLightSymbolLoader.SLSCopyBestManagedDisplayForPoint
@@ -142,6 +141,28 @@ enum SkyLightToolBelt {
         let displayID = CGDisplayGetDisplayIDFromUUID(uuid)
         return displayID != 0 ? displayID : nil
     }
+
+    /// Finds the topmost window at a given screen position.
+    /// - Parameter position: The screen position to check.
+    /// - Returns: The `CGWindowID` of the window at the position, or `nil` if none found.
+    static func windowIDAtPosition(_ position: CGPoint) -> CGWindowID? {
+        guard let SLSMainConnectionID = SkyLightSymbolLoader.SLSMainConnectionID,
+              let SLSFindWindowByGeometry = SkyLightSymbolLoader.SLSFindWindowByGeometry
+        else {
+            return nil
+        }
+
+        let cid = SLSMainConnectionID()
+        var screenPoint = position
+        var windowPoint = CGPoint.zero
+        var hitWindowID: CGWindowID = 0
+        var windowCID: Int32 = 0
+
+        _ = SLSFindWindowByGeometry(cid, 0, 1, 0, &screenPoint, &windowPoint, &hitWindowID, &windowCID)
+
+        return hitWindowID != 0 ? hitWindowID : nil
+    }
+
     /// Captures images for each of the windows that are passed in.
     /// - Parameter windowIDs: The `CGWindowID`s for each of the windows to capture.
     /// - Returns: An array of `CGImage`s for each window, in the same order as the windows that were passed in.

--- a/Loop/Window Management/Window/Window.swift
+++ b/Loop/Window Management/Window/Window.swift
@@ -91,6 +91,18 @@ final class Window {
         )
     }
 
+    /// Retrieve a window from a `CGWindowID`.
+    /// - Parameter windowID: The window ID to look up.
+    static func fromWindowID(_ windowID: CGWindowID) throws -> Window {
+        guard let windowInfoList = CGWindowListCopyWindowInfo([.optionIncludingWindow], windowID) as? [[String: AnyObject]],
+              let windowInfo = windowInfoList.first
+        else {
+            throw WindowError.cannotGetWindow
+        }
+
+        return try fromWindowInfo(windowInfo)
+    }
+
     /// Retrieve a window from an entry in a dictionary returned by `CGWindowListCopyWindowInfo`.
     /// - Parameter windowInfo: The dictionary containing information about the window.
     static func fromWindowInfo(_ windowInfo: [String: AnyObject]) throws -> Window {

--- a/Loop/Window Management/Window/WindowUtility.swift
+++ b/Loop/Window Management/Window/WindowUtility.swift
@@ -51,6 +51,12 @@ enum WindowUtility {
     /// - Parameter position: The position to check for
     /// - Returns: The window at the given position, if any
     static func windowAtPosition(_ position: CGPoint) -> Window? {
+        // Try SkyLight first, as it is faster and doesn't deadlock on own process
+        if let windowID = SkyLightToolBelt.windowIDAtPosition(position),
+           let window = try? Window.fromWindowID(windowID) {
+            return window
+        }
+
         do {
             // If we can find the window at a point using the Accessibility API, return it
             if let element = try AXUIElement.systemWide.getElementAtPosition(position),


### PR DESCRIPTION
Adds two private SkyLight APIs: `SLSCopyBestManagedDisplayForPoint` and `SLSFindWindowByGeometry`.

`SLSCopyBestManagedDisplayForPoint`
Picks the display at a given point using the system's own selection logic instead of our manual bounds iteration. Not really a performance win, but the value is that we match WindowServer's tie-breaking at boundaries, so we can't drift from it (in practice the two seem to agree, though matching the source-of-truth is cheap insurance). Falls back to the old iteration if the symbol fails to load.

`SLSFindWindowByGeometry`
Finds the window at the mouse position. Previously we'd ask AX for the UI element under the cursor, or fall back to walking `CGWindowListCopyWindowInfo` and taking the first frame that contained the point. The fallback was unreliable, as it _could_ skip the frontmost window and return one obscured beneath the actual target. SkyLight's geometry hit-test gives us the right window directly. If this symbol is unavailable, we still fall back to the old system.