### PR TITLE
✨ Add `SLSGetWindowLevel` inside window validation checks

### DIFF
--- a/Loop/Private APIs/SkyLightSymbolLoader.swift
+++ b/Loop/Private APIs/SkyLightSymbolLoader.swift
@@ -104,6 +104,9 @@ extension SkyLightSymbolLoader {
     typealias SLSSetWindowBackgroundBlurRadiusFunc = @convention(c) (_ connection: SLSConnectionID, _ wid: CGWindowID, _ radius: Int) -> OSStatus
     static let SLSSetWindowBackgroundBlurRadius: SLSSetWindowBackgroundBlurRadiusFunc? = loadSymbol("SLSSetWindowBackgroundBlurRadius")
 
+    typealias SLSGetWindowLevelFunc = @convention(c) (_ cid: SLSConnectionID, _ wid: CGWindowID, _ outLevel: UnsafeMutablePointer<Int32>) -> CGError
+    static let SLSGetWindowLevel: SLSGetWindowLevelFunc? = loadSymbol("SLSGetWindowLevel")
+
     /// Options are described by `SLSWindowCaptureOptions`
     typealias SLSHWCaptureWindowListFunc = @convention(c) (_ cid: SLSConnectionID, _ windowList: UnsafeMutablePointer<CGWindowID>, _ windowCount: Int, _ options: UInt32) -> Unmanaged<CFArray>
     static let SLSHWCaptureWindowList: SLSHWCaptureWindowListFunc? = loadSymbol("SLSHWCaptureWindowList")

--- a/Loop/Private APIs/SkyLightToolBelt.swift
+++ b/Loop/Private APIs/SkyLightToolBelt.swift
@@ -189,6 +189,28 @@ enum SkyLightToolBelt {
         return images
     }
 
+    /// Retrieves the CGWindowLevel for a specific window.
+    /// - Parameter windowID: The `CGWindowID` of the window to query.
+    /// - Returns: The window's level, or `nil` if the lookup failed.
+    static func getWindowLevel(windowID: CGWindowID) -> CGWindowLevel? {
+        guard let SLSMainConnectionID = SkyLightSymbolLoader.SLSMainConnectionID,
+              let SLSGetWindowLevel = SkyLightSymbolLoader.SLSGetWindowLevel
+        else {
+            log.error("Failed to load SkyLight symbols in \(#function)")
+            return nil
+        }
+
+        var level: Int32 = 0
+        let status = SLSGetWindowLevel(SLSMainConnectionID(), windowID, &level)
+
+        guard status == .success else {
+            log.error("Failed to get window level for \(windowID): \(status.rawValue)")
+            return nil
+        }
+
+        return level
+    }
+
     /// Retrieves the corner radii for a specific window.
     /// - Parameter windowID: The `CGWindowID` of the window
     /// - Returns: The corner radii of the window if the operation was successful, or `nil` otherwise.

--- a/Loop/Window Management/Window/Window.swift
+++ b/Loop/Window Management/Window/Window.swift
@@ -14,6 +14,7 @@ enum WindowError: LocalizedError {
     case blockedBundleID
     case cannotGetWindow
     case filteredOutFromWindowInfo
+    case invalidWindowLevel(CGWindowLevel)
 
     var errorDescription: String? {
         switch self {
@@ -25,6 +26,8 @@ enum WindowError: LocalizedError {
             "Could not get the element's window"
         case .filteredOutFromWindowInfo:
             "Filtered out from window info"
+        case let .invalidWindowLevel(level):
+            "Invalid window: level \(level) is outside the manageable range"
         }
     }
 }
@@ -35,6 +38,11 @@ final class Window {
     let cgWindowID: CGWindowID
     let pid: pid_t
     let nsRunningApplication: NSRunningApplication?
+
+    private static let invalidBundleIDs: Set<String> = [
+        "com.apple.PIPAgent", // PIP windows
+        "com.apple.notificationcenterui" // Widgets & Notification Center
+    ]
 
     var isOwnWindow: Bool {
         nsRunningApplication?.bundleIdentifier == Bundle.main.bundleIdentifier
@@ -66,13 +74,13 @@ final class Window {
             throw WindowError.sheetWindow
         }
 
-        let invalidBundleIdentifiers: [String] = [
-            "com.apple.PIPAgent", // PIP windows
-            "com.apple.notificationcenterui" // Widgets & Notification Center
-        ]
+        if let level = SkyLightToolBelt.getWindowLevel(windowID: cgWindowID),
+           level < kCGNormalWindowLevel || level > kCGDraggingWindowLevel {
+            throw WindowError.invalidWindowLevel(level)
+        }
 
         if let bundleIdentifier = nsRunningApplication?.bundleIdentifier,
-           invalidBundleIdentifiers.contains(bundleIdentifier) {
+           Self.invalidBundleIDs.contains(bundleIdentifier) {
             throw WindowError.blockedBundleID
         }
     }
@@ -114,9 +122,9 @@ final class Window {
             throw WindowError.filteredOutFromWindowInfo
         }
 
-        if let level = windowInfo[kCGWindowLayer as String] as? Int,
+        if let level = windowInfo[kCGWindowLayer as String] as? CGWindowLevel,
            level < kCGNormalWindowLevel || level > kCGDraggingWindowLevel {
-            throw WindowError.filteredOutFromWindowInfo
+            throw WindowError.invalidWindowLevel(level)
         }
 
         let element = AXUIElementCreateApplication(pid)


### PR DESCRIPTION
Previously, the window level check only existed in `Window.fromWindowInfo`, since that was the only public way to retrieve a window's level. With SkyLight, we can now fetch a window's `CGWindowLevel` directly via `SLSGetWindowLevel`, allowing the check to live in `Window`'s main initializer and apply to every code path. This lets Loop automatically reject intentionally floating windows (such as the notch window from Alcove and likely other notch apps) instead of relying on per-app blacklisting to keep Loop from manipulating them.

Note that the original `Window.fromWindowInfo` check has been kept as an early bail-out, as it lets Loop reject invalid windows up front using data already in hand, avoiding an unnecessary `SkyLight` call :)