### PR TITLE
🐞 Fix stack overflow crash on window-move actions

### DIFF
--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -131,6 +131,13 @@ final class ResizeContext {
     }
 
     private func recomputeTargetFrame() {
+        // Clear the recompute guard *before* resolving so this method is re-entrancy safe:
+        // if `WindowFrameResolver.getFrame` ever reads `getTargetFrame()` on this same
+        // context while it is still being computed, the guard is already clear and the
+        // re-entrant call returns the cached frame instead of recomputing and recursing
+        // until the stack overflows.
+        needsRecompute = false
+
         let result = WindowFrameResolver.getFrame(resizeContext: self)
 
         let normalized = CGRect(
@@ -152,7 +159,6 @@ final class ResizeContext {
             normalized: normalized,
             padded: paddedFrame
         )
-        needsRecompute = false
 
         log.info("Computed target frame - raw: \(cachedTargetFrame.raw), normalized: \(cachedTargetFrame.normalized) padded: \(cachedTargetFrame.padded), for action: \(action)")
     }

--- a/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
+++ b/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
@@ -201,7 +201,12 @@ extension WindowFrameResolver {
             )
 
         } else if direction.willMove {
-            let frameToResizeFrom = context.getTargetFrame().raw
+            // Read the last applied frame (falling back to the cached target) instead of
+            // `context.getTargetFrame()`. `getTargetFrame()` would recompute this very
+            // context and re-enter here, recursing until the stack overflows. Matching the
+            // grow/shrink branches above also keeps moves anchored to the window's actual
+            // position rather than a theoretical (possibly clamped-away) target frame.
+            let frameToResizeFrom = context.lastAppliedFrame ?? context.cachedTargetFrame.raw
 
             result = calculatePositionAdjustment(for: action, frameToResizeFrom: frameToResizeFrom)
 


### PR DESCRIPTION
## Summary

Window-move actions (`moveUp` / `moveDown` / `moveLeft` / `moveRight`) crash Loop with `EXC_BAD_ACCESS` (stack overflow) as soon as they're triggered — via a keybind, the radial-menu preview, or a `loop://direction/Move…` URL.

## Root cause

`WindowFrameResolver.calculateTargetFrame(...)` resolves the `willMove` branch by reading `context.getTargetFrame()`. `ResizeContext.getTargetFrame()` lazily calls `recomputeTargetFrame()`, which calls `WindowFrameResolver.getFrame(resizeContext: self)` on the **same** context — re-entering the `willMove` branch and calling `getTargetFrame()` again. Since `needsRecompute` is only cleared at the *end* of `recomputeTargetFrame()`, the re-entrant call recomputes again → infinite mutual recursion → stack overflow.

Crash backtrace (abridged):

```
0  libswiftCore  swift_beginAccess
2  Loop  static WindowFrameResolver.getFrame(resizeContext:)
3  Loop  ResizeContext.recomputeTargetFrame()
4  Loop  static WindowFrameResolver.calculateTargetFrame(sidesToAdjust:context:)
5  Loop  static WindowFrameResolver.getFrame(resizeContext:)
…  (repeats until KERN_PROTECTION_FAILURE at the stack guard page)
```

## Fix

- **`WindowFrameResolver.swift`** — the `willMove` branch now reads `lastAppliedFrame ?? cachedTargetFrame.raw` (matching the grow/shrink branches) instead of `getTargetFrame()`. This removes the self-recursion at its source, and anchors moves to the window's actual position rather than a theoretical, possibly clamped-away target frame (also fixing move drift on size-constrained windows).
- **`ResizeContext.swift`** (defensive) — `recomputeTargetFrame()` clears `needsRecompute` *before* resolving, so any future re-entrant `getTargetFrame()` returns the cached frame instead of recursing. Not strictly required after the resolver change; happy to drop it if you'd prefer a minimal one-file diff.

## Testing

**Before:** `open "loop://direction/MoveLeft"` on a focused window → immediate `EXC_BAD_ACCESS` crash with the recursion backtrace above.

**After:** same trigger (MoveLeft + MoveRight) → resolver computes the frame, the window moves, action recorded, no crash:

```
[URLCommandHandler] Executing direction: MoveLeft
[URLCommandHandler] Found 14 eligible windows
[ResizeContext] Computed target frame … for action: WindowAction(direction: MoveLeft)
[WindowEngine] Resizing Window(…) to (4061.0, 867.0, 399.0, 455.0)
```

`swiftformat --lint` is clean; built with the `Loop` scheme (Release).
