### PR TITLE
🐞 Fix crash when a cycle action has an empty cycle

### DIFF
--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -474,7 +474,8 @@ extension LoopManager {
     }
 
     private func getNextCycleAction(_ action: WindowAction) async -> WindowAction {
-        guard let currentCycle = action.cycle else {
+        // `currentCycle[0]` below would trap on an empty cycle.
+        guard let currentCycle = action.cycle, !currentCycle.isEmpty else {
             return action
         }
 


### PR DESCRIPTION
## Summary
A cycle action configured with an **empty** cycle list crashes Loop with `EXC_BREAKPOINT` (SIGTRAP) — an out-of-bounds array access.

## Root cause
`LoopManager.getNextCycleAction` guards `action.cycle` against `nil` but not against an *empty* array, then does `currentCycle[0]` on the cycle-restart path and the "no current index" fallback. An empty cycle → `currentCycle[0]` traps.

Crash (abridged): `EXC_BREAKPOINT` in `LoopManager.getNextCycleAction` → `changeAction` → `openLoop`.

## Fix
Guard against an empty cycle too, returning the action unchanged (there's nothing to advance to).

## Testing
Built (Release). A cycle action with zero sub-actions no longer crashes; non-empty cycles are unaffected — the guard only changes the empty case.
