### PR TITLE
🐞 Don't let no-op actions clobber the cached base frame (grow-from-zero)

### DIFF
--- a/Loop/Window Action Indicators/Preview Window/PreviewViewModel.swift
+++ b/Loop/Window Action Indicators/Preview Window/PreviewViewModel.swift
@@ -43,9 +43,14 @@ final class PreviewViewModel: ObservableObject {
             paddedFrame.origin.y -= bounds.minY
         }
 
+        // Frameless actions (no-op, minimize/hide, focus, space/screen switching) have no target
+        // frame; hide the preview rather than leaving the previous action's cached frame on screen
+        // (`recomputeTargetFrame` deliberately keeps that cache so grow/shrink/move can resize from it).
         // In settings preview, actions that manipulate existing window frames (larger/smaller,
         // grow/shrink, move) cannot be previewed without a real window.
-        let shouldBecomeVisible = if isSettingsPreview, context.action.willManipulateExistingWindowFrame {
+        let shouldBecomeVisible = if !context.action.direction.hasTargetFrame {
+            false
+        } else if isSettingsPreview, context.action.willManipulateExistingWindowFrame {
             false
         } else {
             paddedFrame.size.area > 0

--- a/Loop/Window Management/Window Action/WindowDirection.swift
+++ b/Loop/Window Management/Window Action/WindowDirection.swift
@@ -118,6 +118,15 @@ enum WindowDirection: String, CaseIterable, Identifiable, Codable {
     var willCenter: Bool { [.center, .macOSCenter, .verticalCenterHalf, .horizontalCenterHalf].contains(self) }
     var isCustomizable: Bool { [.custom, .stash].contains(self) }
 
+    /// Whether this direction resolves to a concrete target frame. False for no-op,
+    /// minimize/hide/minimizeOthers, cycle, and focus/space/screen-switching actions —
+    /// none of which produce a frame. Shared by `WindowFrameResolver.getFrame` and
+    /// `ResizeContext.recomputeTargetFrame` so the two "no-frame" lists can't drift apart.
+    var hasTargetFrame: Bool {
+        let noFrameActions: [WindowDirection] = [.noAction, .noSelection, .cycle, .minimize, .minimizeOthers, .hide]
+        return !(noFrameActions.contains(self) || willFocusWindow || willChangeSpace || willChangeScreen)
+    }
+
     var hasRadialMenuAngle: Bool {
         let noAngleActions: [WindowDirection] = [.noAction, .noSelection, .minimize, .minimizeOthers, .hide, .initialFrame, .undo, .cycle]
         return !(noAngleActions.contains(self) || shouldFillRadialMenu || willChangeScreen || willChangeSpace || willAdjustSize || willShrink || willGrow || willMove || willFocusWindow)

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -138,6 +138,13 @@ final class ResizeContext {
         // until the stack overflows.
         needsRecompute = false
 
+        // No-op / no-frame actions return a zero-size sentinel from `getFrame`; caching it would
+        // clobber the base frame that a later grow/shrink/move reads. Keep the real cached frame.
+        let noFrameActions: [WindowDirection] = [.noAction, .noSelection, .cycle, .minimize, .hide]
+        guard !noFrameActions.contains(action.direction), !action.direction.willFocusWindow else {
+            return
+        }
+
         let result = WindowFrameResolver.getFrame(resizeContext: self)
 
         let normalized = CGRect(

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -80,6 +80,15 @@ final class ResizeContext {
         resolvedRecord = nil
         lastAppliedFrame = nil
 
+        // Reset the cached base frame to the new window's actual frame. Otherwise a sequence
+        // like `focus to another window > grow` would resize the newly-focused window using
+        // the *previous* window's cached frame — grow/shrink/move read `cachedTargetFrame.raw`
+        // as their base until a frame has been applied.
+        if let window {
+            let frame = window.frame
+            cachedTargetFrame = ComputedFrame(raw: frame, normalized: .zero, padded: frame)
+        }
+
         needsRecompute = true
 
         log.info("Set window to \(window?.description ?? "nil")")
@@ -138,10 +147,10 @@ final class ResizeContext {
         // until the stack overflows.
         needsRecompute = false
 
-        // No-op / no-frame actions return a zero-size sentinel from `getFrame`; caching it would
-        // clobber the base frame that a later grow/shrink/move reads. Keep the real cached frame.
-        let noFrameActions: [WindowDirection] = [.noAction, .noSelection, .cycle, .minimize, .hide]
-        guard !noFrameActions.contains(action.direction), !action.direction.willFocusWindow else {
+        // Actions with no target frame return a zero-size sentinel from `getFrame`; caching it
+        // would clobber the base frame that a later grow/shrink/move reads. Keep the real cached
+        // frame. (Uses `WindowDirection.hasTargetFrame`, shared with `WindowFrameResolver`.)
+        guard action.direction.hasTargetFrame else {
             return
         }
 

--- a/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
+++ b/Loop/Window Management/Window Manipulation/WindowFrameResolver.swift
@@ -51,8 +51,7 @@ enum WindowFrameResolver {
         let bounds = resizeContext.paddedBounds
         let direction = action.direction
 
-        let noFrameActions: [WindowDirection] = [.noAction, .noSelection, .cycle, .minimize, .hide]
-        guard !noFrameActions.contains(direction), !direction.willFocusWindow else {
+        guard direction.hasTargetFrame else {
             return (CGRect(origin: bounds.center, size: .zero), nil)
         }
 


### PR DESCRIPTION
## Summary
During a preview-only chord that starts with a no-op action (e.g. trigger + a "do nothing" action bound to a key, then an arrow to grow), the green preview collapses to a **tiny zero-size box in the screen center**, and the subsequent grow/shrink resizes *from that box* instead of the window's real frame.

## Root cause
`ResizeContext` is reused across a chord. `recomputeTargetFrame` **unconditionally** caches the frame returned by `WindowFrameResolver.getFrame`. For no-frame actions (`.noAction`/`.noSelection`/`.cycle`/`.minimize`/`.hide` and window-focus actions), `getFrame` returns a zero-size centered sentinel — which then overwrites `cachedTargetFrame.raw`. When the user next presses grow/shrink/move, `WindowFrameResolver.calculateTargetFrame` reads `context.lastAppliedFrame ?? context.cachedTargetFrame.raw` as its base. In a preview-only chord `lastAppliedFrame` is still `nil` (it's only set on an actual apply), so it falls through to the polluted `cachedTargetFrame.raw` = the zero box, and grows from zero.

Pre-refactor (1.4.2) never cached the sentinel: its no-op early-return sat *before* the `lastTargetFrame` store, so the grow base stayed the real window frame. The refactor into `recomputeTargetFrame` lost that invariant.

## Fix
Skip caching in `recomputeTargetFrame` for no-op / no-frame / window-focus actions (mirroring the guard already in `WindowFrameResolver.getFrame`), preserving the previously-cached real frame. Incremental grow during preview still works because real actions keep updating `cachedTargetFrame.raw`.

## Testing
Built (Release) and verified: `trigger + do-nothing + Up` now grows from the window's real frame; repeated grow/shrink still steps correctly; normal single actions unaffected.
