### PR TITLE
🐞 Harden window focus sequence

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -124,5 +124,5 @@
 --xcode-indentation disabled
 --xctest-symbols 
 --yoda-swap always
---disable genericExtensions,redundantVariable,simplifyGenericConstraints,wrapMultilineStatementBraces,wrapPropertyBodies
+--disable genericExtensions,redundantVariable,simplifyGenericConstraints,wrapFunctionBodies,wrapIfExpressionBodies,wrapIfStatementBodies,wrapLoopBodies,wrapMultilineStatementBraces,wrapPropertyBodies
 --enable isEmpty

--- a/Loop/Private APIs/SkyLightToolBelt.swift
+++ b/Loop/Private APIs/SkyLightToolBelt.swift
@@ -91,35 +91,42 @@ enum SkyLightToolBelt {
         return true
     }
 
-    ///
-    /// Byte layout for the synthetic `CGSEventRecord` posted by `makeKeyWindow`.
-    /// Offsets match CGSInternal's CGSEvent.h / yabai / AltTab.
+    /// Byte layout for the `CGSEventRecord` posted by `makeKeyWindow`.
+    /// Offsets are from CGSInternal's CGSEvent.h:
+    /// https://github.com/NUIKit/CGSInternal/blob/master/CGSEvent.h
     private enum MakeKeyWindowEvent {
-        /// Allocated buffer size. The record's declared length stays `recordLength`;
-        /// we allocate a little more because newer macOS WindowServer encoding can
-        /// read past the record (see AltTab / paneru#123).
+        /// Allocated buffer size. The record itself remains `recordLength` bytes; the extra zeroed padding
+        /// prevents WindowServer encoding from reading beyond the allocation on macOS 14.7.4 and later.
+        /// See:
+        /// https://github.com/karinushka/paneru/issues/123
         static let bufferSize = 0x100
+        /// The record's declared length.
         static let lengthOffset = 0x04
         static let recordLength: UInt8 = 0xF8
+        /// The `CGSEventType`, matching the public `CGEventType` values. A mouse-down is enough to make the
+        /// window key; omitting mouse-up prevents the event from activating a control. Thanks to AltTab for
+        /// testing this behavior:
+        /// https://github.com/lwouis/alt-tab-macos/commit/ec30bb13084e68cb3cde32ec415fdba1fd92876e
         static let eventTypeOffset = 0x08
-        static let leftMouseDown: UInt8 = 0x01
-        static let leftMouseUp: UInt8 = 0x02
-        /// Window-relative click point. Just outside the frame so the window becomes
-        /// key without hitting content. Must be finite — `0xFF` fill decodes as NaN
-        /// and can terminate Chromium PWA app-shim Mojo connections (#1131).
+        static let leftMouseDown: UInt8 = 0x01 // kCGEventLeftMouseDown
+        /// The window-relative event point. This must be finite: filling these bytes with `0xFF` produces NaN,
+        /// which can terminate Chromium PWA app-shim Mojo connections (#1132). It must also be far from the
+        /// frame, since we (and AltTab) found that `(-1, -1)` can land in the resize region on macOS 27 and expand the
+        /// window. A far bottom-right point avoids both issues and favors less interactive content if an app clamps it.
         static let windowLocationOffset = 0x20
-        static let offContentPoint = CGPoint(x: -1, y: -1)
+        static let offContentPoint = CGPoint(x: 300_000, y: 300_000)
+        /// The target `CGWindowID`. The event is delivered by id, not by the point above.
+        static let windowIdOffset = 0x3C
+        /// Undocumented flag retained from the upstream implementations.
         static let unknownFlagOffset = 0x3A
         static let unknownFlagValue: UInt8 = 0x10
-        static let windowIdOffset = 0x3C
     }
 
-    /// Focuses a window. This will attempt to bring the window to the front and make it the active window.
-    /// Note that this first sets the process as frontmost, *then* sends a left click event to the window itself.
+    /// Makes a window key within its owning process by posting a synthetic left-mouse-down event.
     ///
     /// Uses a private API. Derived from Hammerspoon / yabai / AltTab
     /// (https://github.com/Hammerspoon/hammerspoon/issues/370#issuecomment-545545468,
-    /// https://github.com/lwouis/alt-tab-macos/commit/782f1fe2e7272f185526e3e69eadd08c241fe050).
+    /// https://github.com/lwouis/alt-tab-macos/commit/ec30bb13084e68cb3cde32ec415fdba1fd92876e).
     ///
     /// - Parameters:
     ///   - windowID: The `CGWindowID` of the window to focus.
@@ -142,22 +149,20 @@ enum SkyLightToolBelt {
 
         var offContentPoint = MakeKeyWindowEvent.offContentPoint
 
-        for eventType in [MakeKeyWindowEvent.leftMouseDown, MakeKeyWindowEvent.leftMouseUp] {
-            var bytes = [UInt8](repeating: 0, count: MakeKeyWindowEvent.bufferSize)
-            bytes[MakeKeyWindowEvent.lengthOffset] = MakeKeyWindowEvent.recordLength
-            bytes[MakeKeyWindowEvent.eventTypeOffset] = eventType
-            bytes[MakeKeyWindowEvent.unknownFlagOffset] = MakeKeyWindowEvent.unknownFlagValue
-            memcpy(&bytes[MakeKeyWindowEvent.windowIdOffset], &wid, MemoryLayout<UInt32>.size)
-            memcpy(&bytes[MakeKeyWindowEvent.windowLocationOffset], &offContentPoint, MemoryLayout<CGPoint>.size)
+        var bytes = [UInt8](repeating: 0, count: MakeKeyWindowEvent.bufferSize)
+        bytes[MakeKeyWindowEvent.lengthOffset] = MakeKeyWindowEvent.recordLength
+        bytes[MakeKeyWindowEvent.eventTypeOffset] = MakeKeyWindowEvent.leftMouseDown
+        bytes[MakeKeyWindowEvent.unknownFlagOffset] = MakeKeyWindowEvent.unknownFlagValue
+        memcpy(&bytes[MakeKeyWindowEvent.windowIdOffset], &wid, MemoryLayout<CGWindowID>.size)
+        memcpy(&bytes[MakeKeyWindowEvent.windowLocationOffset], &offContentPoint, MemoryLayout<CGPoint>.size)
 
-            let cgStatus = bytes.withUnsafeMutableBufferPointer { pointer in
-                SLPSPostEventRecordTo(&psn, &pointer.baseAddress!.pointee)
-            }
+        let cgStatus = bytes.withUnsafeMutableBufferPointer { pointer in
+            SLPSPostEventRecordTo(&psn, &pointer.baseAddress!.pointee)
+        }
 
-            guard cgStatus == .success else {
-                log.error("Failed to click frontmost process with status: \(cgStatus.rawValue)")
-                return false
-            }
+        guard cgStatus == .success else {
+            log.error("Failed to post key-window event with status: \(cgStatus.rawValue)")
+            return false
         }
 
         return true

--- a/Loop/Settings Window/Settings/Behavior/Padding Configuration/PaddingConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Behavior/Padding Configuration/PaddingConfigurationView.swift
@@ -133,89 +133,87 @@ struct PaddingConfigurationView: View {
         )
     }
 
+    @ViewBuilder
     func screenSidesPaddingConfiguration() -> some View {
-        Group {
-            LuminareSlider(
-                String(localized: "Top", comment: "Label for a slider in Loop’s padding settings"),
-                value: $paddingModel.top.doubleBinding,
-                in: range,
-                format: .number.precision(.fractionLength(0...1)),
-                clampsUpper: false,
-                suffix: Text("px", comment: "Unit symbol: pixels"),
-                onEditingChanged: handleSliderEditingChanged,
-                onEditingCommit: commitSliderChanges
-            )
-            .luminareSliderLayout(.compact(textBoxWidth: 76))
+        LuminareSlider(
+            String(localized: "Top", comment: "Label for a slider in Loop’s padding settings"),
+            value: $paddingModel.top.doubleBinding,
+            in: range,
+            format: .number.precision(.fractionLength(0...1)),
+            clampsUpper: false,
+            suffix: Text("px", comment: "Unit symbol: pixels"),
+            onEditingChanged: handleSliderEditingChanged,
+            onEditingCommit: commitSliderChanges
+        )
+        .luminareSliderLayout(.compact(textBoxWidth: 76))
 
-            LuminareSlider(
-                String(localized: "Bottom", comment: "Label for a slider in Loop’s padding settings"),
-                value: $paddingModel.bottom.doubleBinding,
-                in: range,
-                format: .number.precision(.fractionLength(0...1)),
-                clampsUpper: false,
-                suffix: Text("px", comment: "Unit symbol: pixels"),
-                onEditingChanged: handleSliderEditingChanged,
-                onEditingCommit: commitSliderChanges
-            )
-            .luminareSliderLayout(.compact(textBoxWidth: 76))
+        LuminareSlider(
+            String(localized: "Bottom", comment: "Label for a slider in Loop’s padding settings"),
+            value: $paddingModel.bottom.doubleBinding,
+            in: range,
+            format: .number.precision(.fractionLength(0...1)),
+            clampsUpper: false,
+            suffix: Text("px", comment: "Unit symbol: pixels"),
+            onEditingChanged: handleSliderEditingChanged,
+            onEditingCommit: commitSliderChanges
+        )
+        .luminareSliderLayout(.compact(textBoxWidth: 76))
 
-            LuminareSlider(
-                String(localized: "Right", comment: "Label for a slider in Loop’s padding settings"),
-                value: $paddingModel.right.doubleBinding,
-                in: range,
-                format: .number.precision(.fractionLength(0...1)),
-                clampsUpper: false,
-                suffix: Text("px", comment: "Unit symbol: pixels"),
-                onEditingChanged: handleSliderEditingChanged,
-                onEditingCommit: commitSliderChanges
-            )
-            .luminareSliderLayout(.compact(textBoxWidth: 76))
+        LuminareSlider(
+            String(localized: "Right", comment: "Label for a slider in Loop’s padding settings"),
+            value: $paddingModel.right.doubleBinding,
+            in: range,
+            format: .number.precision(.fractionLength(0...1)),
+            clampsUpper: false,
+            suffix: Text("px", comment: "Unit symbol: pixels"),
+            onEditingChanged: handleSliderEditingChanged,
+            onEditingCommit: commitSliderChanges
+        )
+        .luminareSliderLayout(.compact(textBoxWidth: 76))
 
-            LuminareSlider(
-                String(localized: "Left", comment: "Label for a slider in Loop’s padding settings"),
-                value: $paddingModel.left.doubleBinding,
-                in: range,
-                format: .number.precision(.fractionLength(0...1)),
-                clampsUpper: false,
-                suffix: Text("px", comment: "Unit symbol: pixels"),
-                onEditingChanged: handleSliderEditingChanged,
-                onEditingCommit: commitSliderChanges
-            )
-            .luminareSliderLayout(.compact(textBoxWidth: 76))
-        }
+        LuminareSlider(
+            String(localized: "Left", comment: "Label for a slider in Loop’s padding settings"),
+            value: $paddingModel.left.doubleBinding,
+            in: range,
+            format: .number.precision(.fractionLength(0...1)),
+            clampsUpper: false,
+            suffix: Text("px", comment: "Unit symbol: pixels"),
+            onEditingChanged: handleSliderEditingChanged,
+            onEditingCommit: commitSliderChanges
+        )
+        .luminareSliderLayout(.compact(textBoxWidth: 76))
     }
 
+    @ViewBuilder
     func screenInsetsPaddingConfiguration() -> some View {
-        Group {
-            LuminareSlider(
-                String(localized: "Window gaps", comment: "Label for a slider in Loop’s padding settings"),
-                value: $paddingModel.window.doubleBinding,
-                in: range,
-                format: .number.precision(.fractionLength(0...1)),
-                clampsUpper: false,
-                suffix: Text("px", comment: "Unit symbol: pixels"),
-                onEditingChanged: handleSliderEditingChanged,
-                onEditingCommit: commitSliderChanges
-            )
-            .luminareSliderLayout(.compact(textBoxWidth: 76))
+        LuminareSlider(
+            String(localized: "Window gaps", comment: "Label for a slider in Loop’s padding settings"),
+            value: $paddingModel.window.doubleBinding,
+            in: range,
+            format: .number.precision(.fractionLength(0...1)),
+            clampsUpper: false,
+            suffix: Text("px", comment: "Unit symbol: pixels"),
+            onEditingChanged: handleSliderEditingChanged,
+            onEditingCommit: commitSliderChanges
+        )
+        .luminareSliderLayout(.compact(textBoxWidth: 76))
 
-            LuminareSlider(
-                value: $paddingModel.externalBar.doubleBinding,
-                in: range,
-                format: .number.precision(.fractionLength(0...1)),
-                suffix: Text("px", comment: "Unit symbol: pixels"),
-                onEditingChanged: handleSliderEditingChanged,
-                onEditingCommit: commitSliderChanges
-            ) {
-                Text("External bar", comment: "Label for a slider in Loop’s padding settings")
-                    .padding(.trailing, 4)
-                    .luminareToolTip(attachedTo: .topTrailing) {
-                        Text("Use this if you are using a custom menubar.")
-                            .padding(6)
-                    }
-            }
-            .luminareSliderLayout(.compact(textBoxWidth: 76))
+        LuminareSlider(
+            value: $paddingModel.externalBar.doubleBinding,
+            in: range,
+            format: .number.precision(.fractionLength(0...1)),
+            suffix: Text("px", comment: "Unit symbol: pixels"),
+            onEditingChanged: handleSliderEditingChanged,
+            onEditingCommit: commitSliderChanges
+        ) {
+            Text("External bar", comment: "Label for a slider in Loop’s padding settings")
+                .padding(.trailing, 4)
+                .luminareToolTip(attachedTo: .topTrailing) {
+                    Text("Use this if you are using a custom menubar.")
+                        .padding(6)
+                }
         }
+        .luminareSliderLayout(.compact(textBoxWidth: 76))
     }
 
     private func handleSliderEditingChanged(_ isEditing: Bool) {

--- a/Loop/Settings Window/Settings/Keybinds/KeybindsConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/KeybindsConfigurationView.swift
@@ -68,42 +68,41 @@ struct KeybindsConfigurationView: View {
         .luminareBorderedStates(.none)
     }
 
+    @ViewBuilder
     private var settingsSection: some View {
-        Group {
-            LuminareSection(String(localized: "Settings", comment: "Section header shown in settings")) {
-                LuminareToggle("Treat left and right keys differently", isOn: $sideDependentTriggerKey)
+        LuminareSection(String(localized: "Settings", comment: "Section header shown in settings")) {
+            LuminareToggle("Treat left and right keys differently", isOn: $sideDependentTriggerKey)
 
-                LuminareSlider(
-                    "Trigger delay",
-                    value: $triggerDelay,
-                    in: 0...1,
-                    step: 0.1,
-                    format: .number.precision(.fractionLength(1...1)),
-                    clampsUpper: false,
-                    suffix: Text("s", comment: "Unit symbol: seconds")
-                )
+            LuminareSlider(
+                "Trigger delay",
+                value: $triggerDelay,
+                in: 0...1,
+                step: 0.1,
+                format: .number.precision(.fractionLength(1...1)),
+                clampsUpper: false,
+                suffix: Text("s", comment: "Unit symbol: seconds")
+            )
 
-                LuminareToggle("Double-click to trigger", isOn: $doubleClickToTrigger)
-                LuminareToggle("Middle-click to trigger", isOn: $middleClickTriggersLoop)
+            LuminareToggle("Double-click to trigger", isOn: $doubleClickToTrigger)
+            LuminareToggle("Middle-click to trigger", isOn: $middleClickTriggersLoop)
 
-                if showMiddleClickTriggerDelayOption {
-                    LuminareToggle("Apply trigger delay on middle-click", isOn: $enableTriggerDelayOnMiddleClick)
-                }
+            if showMiddleClickTriggerDelayOption {
+                LuminareToggle("Apply trigger delay on middle-click", isOn: $enableTriggerDelayOnMiddleClick)
+            }
+        }
+
+        LuminareSection(String(localized: "Cycles", comment: "Section header shown in settings")) {
+            LuminareToggle(isOn: $cycleModeRestartEnabled) {
+                Text("Always start cycles from first item")
+                    .padding(.trailing, 4)
+                    .luminareToolTip(attachedTo: .topTrailing) {
+                        Text("By default, Loop resumes cycles from where you last left off in each window.")
+                            .padding(6)
+                    }
             }
 
-            LuminareSection(String(localized: "Cycles", comment: "Section header shown in settings")) {
-                LuminareToggle(isOn: $cycleModeRestartEnabled) {
-                    Text("Always start cycles from first item")
-                        .padding(.trailing, 4)
-                        .luminareToolTip(attachedTo: .topTrailing) {
-                            Text("By default, Loop resumes cycles from where you last left off in each window.")
-                                .padding(6)
-                        }
-                }
-
-                if !isShiftUsedByTriggerKey {
-                    LuminareToggle("Cycle backward with Shift", isOn: $cycleBackwardsOnShiftPressed)
-                }
+            if !isShiftUsedByTriggerKey {
+                LuminareToggle("Cycle backward with Shift", isOn: $cycleBackwardsOnShiftPressed)
             }
         }
     }

--- a/Loop/Settings Window/Settings/Keybinds/Modal Views/CustomActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Modal Views/CustomActionConfigurationView.swift
@@ -181,177 +181,175 @@ struct CustomActionConfigurationView: View {
         .luminareCornerRadius(8)
     }
 
+    @ViewBuilder
     private func positionConfiguration() -> some View {
-        Group {
-            LuminareToggle(
-                "Use coordinates",
-                isOn: Binding(
-                    get: {
-                        action.positionMode == .coordinates
-                    },
-                    set: { newValue in
-                        withAnimation(luminareAnimation) {
-                            action.positionMode = newValue ? .coordinates : .generic
-                        }
+        LuminareToggle(
+            "Use coordinates",
+            isOn: Binding(
+                get: {
+                    action.positionMode == .coordinates
+                },
+                set: { newValue in
+                    withAnimation(luminareAnimation) {
+                        action.positionMode = newValue ? .coordinates : .generic
                     }
-                )
+                }
             )
+        )
 
-            if action.positionMode ?? .generic == .generic {
-                LuminarePicker(
-                    elements: anchors,
-                    selection: Binding(
-                        get: {
-                            // since center/macOS center use the same icon on the picker
-                            if action.anchor == .macOSCenter {
-                                return .center
-                            }
-
-                            return action.anchor ?? .center
-                        },
-                        set: { newValue in
-                            withAnimation(luminareAnimation) {
-                                action.anchor = newValue
-                            }
-                        }
-                    ),
-                    columns: 3
-                ) { anchor in
-                    if let action = anchor.iconAction {
-                        IconView(action: action)
-                    }
-                }
-                .luminareRoundingBehavior(bottom: !showMacOSCenterToggle)
-
-                if showMacOSCenterToggle {
-                    LuminareToggle(
-                        isOn: Binding(
-                            get: {
-                                action.anchor == .macOSCenter
-                            },
-                            set: {
-                                action.anchor = $0 ? .macOSCenter : .center
-                            }
-                        )
-                    ) {
-                        if let infoText = action.direction.infoText {
-                            Text("Use macOS center", comment: "Toggle to enable macOS-style centering in custom actions")
-                                .padding(.trailing, 4)
-                                .luminareToolTip(attachedTo: .topTrailing) {
-                                    Text(infoText)
-                                        .padding(6)
-                                }
-                        } else {
-                            Text("Use macOS center", comment: "Toggle to enable macOS-style centering in custom actions")
-                        }
-                    }
-                }
-            } else {
-                LuminareSlider(
-                    String(localized: "X", comment: "X axis label"),
-                    value: Binding(
-                        get: {
-                            action.xPoint ?? 0
-                        },
-                        set: {
-                            action.xPoint = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
-
-                LuminareSlider(
-                    String(localized: "Y", comment: "Y axis label"),
-                    value: Binding(
-                        get: {
-                            action.yPoint ?? 0
-                        },
-                        set: {
-                            action.yPoint = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
-            }
-        }
-    }
-
-    private func sizeConfiguration() -> some View {
-        Group {
+        if action.positionMode ?? .generic == .generic {
             LuminarePicker(
-                elements: CustomWindowActionSizeMode.allCases,
+                elements: anchors,
                 selection: Binding(
                     get: {
-                        action.sizeMode ?? .custom
+                        // since center/macOS center use the same icon on the picker
+                        if action.anchor == .macOSCenter {
+                            return .center
+                        }
+
+                        return action.anchor ?? .center
                     },
                     set: { newValue in
                         withAnimation(luminareAnimation) {
-                            action.sizeMode = newValue
+                            action.anchor = newValue
                         }
                     }
                 ),
                 columns: 3
-            ) { mode in
-                VStack(spacing: 4) {
-                    mode.image
-                    Text(mode.name)
+            ) { anchor in
+                if let action = anchor.iconAction {
+                    IconView(action: action)
                 }
-                .padding(.vertical, 15)
-                .compositingGroup()
             }
-            .luminareContentSize(hasFixedHeight: true)
-            .luminareRoundingBehavior(
-                top: true,
-                bottom: action.sizeMode != .custom
+            .luminareRoundingBehavior(bottom: !showMacOSCenterToggle)
+
+            if showMacOSCenterToggle {
+                LuminareToggle(
+                    isOn: Binding(
+                        get: {
+                            action.anchor == .macOSCenter
+                        },
+                        set: {
+                            action.anchor = $0 ? .macOSCenter : .center
+                        }
+                    )
+                ) {
+                    if let infoText = action.direction.infoText {
+                        Text("Use macOS center", comment: "Toggle to enable macOS-style centering in custom actions")
+                            .padding(.trailing, 4)
+                            .luminareToolTip(attachedTo: .topTrailing) {
+                                Text(infoText)
+                                    .padding(6)
+                            }
+                    } else {
+                        Text("Use macOS center", comment: "Toggle to enable macOS-style centering in custom actions")
+                    }
+                }
+            }
+        } else {
+            LuminareSlider(
+                String(localized: "X", comment: "X axis label"),
+                value: Binding(
+                    get: {
+                        action.xPoint ?? 0
+                    },
+                    set: {
+                        action.xPoint = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
             )
 
-            if action.sizeMode ?? .custom == .custom {
-                LuminareSlider(
-                    "Width",
-                    value: Binding(
-                        get: {
-                            action.width ?? 100
-                        },
-                        set: {
-                            action.width = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
+            LuminareSlider(
+                String(localized: "Y", comment: "Y axis label"),
+                value: Binding(
+                    get: {
+                        action.yPoint ?? 0
+                    },
+                    set: {
+                        action.yPoint = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
+            )
+        }
+    }
 
-                LuminareSlider(
-                    "Height",
-                    value: Binding(
-                        get: {
-                            action.height ?? 100
-                        },
-                        set: {
-                            action.height = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
+    @ViewBuilder
+    private func sizeConfiguration() -> some View {
+        LuminarePicker(
+            elements: CustomWindowActionSizeMode.allCases,
+            selection: Binding(
+                get: {
+                    action.sizeMode ?? .custom
+                },
+                set: { newValue in
+                    withAnimation(luminareAnimation) {
+                        action.sizeMode = newValue
+                    }
+                }
+            ),
+            columns: 3
+        ) { mode in
+            VStack(spacing: 4) {
+                mode.image
+                Text(mode.name)
             }
+            .padding(.vertical, 15)
+            .compositingGroup()
+        }
+        .luminareContentSize(hasFixedHeight: true)
+        .luminareRoundingBehavior(
+            top: true,
+            bottom: action.sizeMode != .custom
+        )
+
+        if action.sizeMode ?? .custom == .custom {
+            LuminareSlider(
+                "Width",
+                value: Binding(
+                    get: {
+                        action.width ?? 100
+                    },
+                    set: {
+                        action.width = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
+            )
+
+            LuminareSlider(
+                "Height",
+                value: Binding(
+                    get: {
+                        action.height ?? 100
+                    },
+                    set: {
+                        action.height = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
+            )
         }
     }
 

--- a/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/Modal Views/StashActionConfigurationView.swift
@@ -170,134 +170,132 @@ struct StashActionConfigurationView: View {
         .luminareCornerRadius(8)
     }
 
+    @ViewBuilder
     private func positionConfiguration() -> some View {
-        Group {
-            if action.positionMode ?? .generic == .generic {
-                LuminarePicker(
-                    elements: anchors,
-                    selection: Binding(
-                        get: {
-                            action.anchor ?? defaultAnchor
-                        },
-                        set: { newValue in
-                            withAnimation(luminareAnimation) {
-                                action.anchor = newValue
-                            }
-                        }
-                    ),
-                    columns: 3
-                ) { anchor in
-                    if let action = anchor.iconAction {
-                        IconView(action: action)
-                    }
-                }
-                .luminareRoundingBehavior(top: true, bottom: true)
-            } else {
-                LuminareSlider(
-                    String(localized: "X", comment: "X axis label"),
-                    value: Binding(
-                        get: {
-                            action.xPoint ?? 0
-                        },
-                        set: {
-                            action.xPoint = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
-
-                LuminareSlider(
-                    String(localized: "Y", comment: "Y axis label"),
-                    value: Binding(
-                        get: {
-                            action.yPoint ?? 0
-                        },
-                        set: {
-                            action.yPoint = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
-            }
-        }
-    }
-
-    private func sizeConfiguration() -> some View {
-        Group {
+        if action.positionMode ?? .generic == .generic {
             LuminarePicker(
-                elements: sizeModes,
+                elements: anchors,
                 selection: Binding(
                     get: {
-                        action.sizeMode ?? .custom
+                        action.anchor ?? defaultAnchor
                     },
                     set: { newValue in
                         withAnimation(luminareAnimation) {
-                            action.sizeMode = newValue
+                            action.anchor = newValue
                         }
                     }
                 ),
-                columns: 2
-            ) { mode in
-                VStack(spacing: 4) {
-                    mode.image
-                    Text(mode.name)
+                columns: 3
+            ) { anchor in
+                if let action = anchor.iconAction {
+                    IconView(action: action)
                 }
-                .padding(.vertical, 15)
-                .compositingGroup()
             }
-            .luminareContentSize(hasFixedHeight: true)
-            .luminareRoundingBehavior(
-                top: true,
-                bottom: action.sizeMode != .custom
+            .luminareRoundingBehavior(top: true, bottom: true)
+        } else {
+            LuminareSlider(
+                String(localized: "X", comment: "X axis label"),
+                value: Binding(
+                    get: {
+                        action.xPoint ?? 0
+                    },
+                    set: {
+                        action.xPoint = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
             )
 
-            if action.sizeMode ?? .custom == .custom {
-                LuminareSlider(
-                    "Width",
-                    value: Binding(
-                        get: {
-                            action.width ?? 100
-                        },
-                        set: {
-                            action.width = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
+            LuminareSlider(
+                String(localized: "Y", comment: "Y axis label"),
+                value: Binding(
+                    get: {
+                        action.yPoint ?? 0
+                    },
+                    set: {
+                        action.yPoint = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: Text(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
+            )
+        }
+    }
 
-                LuminareSlider(
-                    "Height",
-                    value: Binding(
-                        get: {
-                            action.height ?? 100
-                        },
-                        set: {
-                            action.height = actionUnit.roundIfNeeded($0)
-                        }
-                    ),
-                    in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
-                    format: .number.precision(actionUnit.fractionLength),
-                    clampsUpper: false,
-                    suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
-                    onEditingChanged: handleSliderEditingChanged,
-                    onEditingCommit: commitSliderChanges
-                )
+    @ViewBuilder
+    private func sizeConfiguration() -> some View {
+        LuminarePicker(
+            elements: sizeModes,
+            selection: Binding(
+                get: {
+                    action.sizeMode ?? .custom
+                },
+                set: { newValue in
+                    withAnimation(luminareAnimation) {
+                        action.sizeMode = newValue
+                    }
+                }
+            ),
+            columns: 2
+        ) { mode in
+            VStack(spacing: 4) {
+                mode.image
+                Text(mode.name)
             }
+            .padding(.vertical, 15)
+            .compositingGroup()
+        }
+        .luminareContentSize(hasFixedHeight: true)
+        .luminareRoundingBehavior(
+            top: true,
+            bottom: action.sizeMode != .custom
+        )
+
+        if action.sizeMode ?? .custom == .custom {
+            LuminareSlider(
+                "Width",
+                value: Binding(
+                    get: {
+                        action.width ?? 100
+                    },
+                    set: {
+                        action.width = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.width),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
+            )
+
+            LuminareSlider(
+                "Height",
+                value: Binding(
+                    get: {
+                        action.height ?? 100
+                    },
+                    set: {
+                        action.height = actionUnit.roundIfNeeded($0)
+                    }
+                ),
+                in: actionUnit == .percentage ? 0...100 : 0...Double(screenSize.height),
+                format: .number.precision(actionUnit.fractionLength),
+                clampsUpper: false,
+                suffix: .init(action.unit?.suffix ?? CustomWindowActionUnit.percentage.suffix),
+                onEditingChanged: handleSliderEditingChanged,
+                onEditingCommit: commitSliderChanges
+            )
         }
     }
 

--- a/Loop/Window Management/Window Action/WindowAction.swift
+++ b/Loop/Window Management/Window Action/WindowAction.swift
@@ -160,12 +160,12 @@ struct WindowAction: Codable, Identifiable, Hashable, Equatable, Defaults.Serial
     /// - Returns: the name of the action.
     func getName() -> String {
         if let name, !name.isEmpty, hasCustomizableName {
-            return name
+            name
         } else {
-            return direction.name
+            direction.name
         }
     }
-    
+
     /// Determines if an action is eligible for custom names set by the user.
     var hasCustomizableName: Bool {
         direction == .custom || direction == .stash || direction == .cycle

--- a/Loop/Window Management/Window/Window.swift
+++ b/Loop/Window Management/Window/Window.swift
@@ -222,30 +222,19 @@ final class Window {
     /// Focus the window.
     @MainActor
     func focus() {
-        // First activate the application to ensure proper window management context
-        if let runningApplication = nsRunningApplication {
-            runningApplication.activate(options: .activateIgnoringOtherApps)
+        let fronted = SkyLightToolBelt.makeFrontProcess(
+            windowID: cgWindowID,
+            pid: pid
+        )
+
+        if !fronted {
+            nsRunningApplication?.activate(options: .activateIgnoringOtherApps)
         }
 
-        try? axWindow.performAction(.raise)
-
-        // See:  https://github.com/yresk/alt-tab-macos/blob/5b8a9110dbdb9b4802a8a85ee1469427fbc192e8/alt-tab-macos/api-wrappers/AXUIElement.swift#L60
-        if let pid = try? axWindow.getPID() {
-            _ = SkyLightToolBelt.makeKeyWindow(
-                windowID: cgWindowID,
-                pid: pid
-            )
-
-            _ = SkyLightToolBelt.makeFrontProcess(
-                windowID: cgWindowID,
-                pid: pid
-            )
-
-            _ = SkyLightToolBelt.makeKeyWindow(
-                windowID: cgWindowID,
-                pid: pid
-            )
-        }
+        _ = SkyLightToolBelt.makeKeyWindow(
+            windowID: cgWindowID,
+            pid: pid
+        )
 
         try? axWindow.performAction(.raise)
     }


### PR DESCRIPTION
Updates Loop's window focus behavior. The previous sequence raised and keyed the window multiple times. It now:

1. Makes the target process and window frontmost,
1. Posts one mouse-down event to make the target window key without completing a click,
1. Raises the window once through Accessibility,
1. Falls back to `NSRunningApplication.activate` if private fronting fails,
1. Uses a far bottom-right event point to avoid Chromium's NaN handling and the window's resize region.

Previously, Loop sent two synthetic clicks at `(-1, -1)` to raise a window. On macOS 27, these could register as a double-click on the title bar and expand the window (interestingly, this did not happen on macOS 26). Moving the point to `(300000, 300000)` and omitting mouse-up prevents the synthetic event from triggering either behavior. The updated focus sequence and coordinate are based on AltTab's current implementation :)