### PR TITLE
🐞 Preserve cycle progress across windows and overlapping keybinds

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -27,6 +27,13 @@
 			remoteGlobalIDString = 2A8689062F809625005B521B;
 			remoteInfo = LoopDockTile;
 		};
+		2ACE2DED3043A6F600C4FECB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A8E59C2D297F5E9A0064D4BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A8E59C34297F5E9A0064D4BA;
+			remoteInfo = Loop;
+		};
 		B1AA00512F30000100AABBCC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A8E59C2D297F5E9A0064D4BA /* Project object */;
@@ -61,6 +68,7 @@
 
 /* Begin PBXFileReference section */
 		2A8689072F809625005B521B /* LoopDockTile.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopDockTile.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ACE2DE93043A6F600C4FECB /* LoopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A848130C2BD1A8D100B02E93 /* .github */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .github; sourceTree = "<group>"; };
 		A86AFD7529888B29008F4892 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A883642E298B7288005D6C19 /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
@@ -111,6 +119,7 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		2A6A87F02F4D20D2004E995D /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2A6A87F22F4D20F4004E995D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
 		2A86890E2F809700005B521B /* LoopDockTile */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = LoopDockTile; sourceTree = "<group>"; };
+		2ACE2DEA3043A6F600C4FECB /* LoopTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = LoopTests; sourceTree = "<group>"; };
 		A8C751AC2D7BA98600B58784 /* Loop */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8C751FF2D7BA98600B58784 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Loop; sourceTree = "<group>"; };
 		B1AA00022F30000100AABBCC /* LoopUpdaterHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2A5DD5CC2F5D270C0077AB3C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LoopUpdaterHelper; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -121,6 +130,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				2AE091C72F81A22800EF6149 /* Scribe in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2ACE2DE63043A6F600C4FECB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -168,6 +184,7 @@
 				A8C751AC2D7BA98600B58784 /* Loop */,
 				B1AA00022F30000100AABBCC /* LoopUpdaterHelper */,
 				2A86890E2F809700005B521B /* LoopDockTile */,
+				2ACE2DEA3043A6F600C4FECB /* LoopTests */,
 				A8E59C36297F5E9A0064D4BA /* Products */,
 				A883642D298B7288005D6C19 /* Frameworks */,
 				2A6A87F02F4D20D2004E995D /* Shared */,
@@ -180,6 +197,7 @@
 				A8E59C35297F5E9A0064D4BA /* Loop.app */,
 				B1AA00012F30000100AABBCC /* LoopUpdaterHelper */,
 				2A8689072F809625005B521B /* LoopDockTile.plugin */,
+				2ACE2DE93043A6F600C4FECB /* LoopTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -209,6 +227,29 @@
 			productName = LoopDockTile;
 			productReference = 2A8689072F809625005B521B /* LoopDockTile.plugin */;
 			productType = "com.apple.product-type.bundle";
+		};
+		2ACE2DE83043A6F600C4FECB /* LoopTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2ACE2DEF3043A6F600C4FECB /* Build configuration list for PBXNativeTarget "LoopTests" */;
+			buildPhases = (
+				2ACE2DE53043A6F600C4FECB /* Sources */,
+				2ACE2DE63043A6F600C4FECB /* Frameworks */,
+				2ACE2DE73043A6F600C4FECB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2ACE2DEE3043A6F600C4FECB /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				2ACE2DEA3043A6F600C4FECB /* LoopTests */,
+			);
+			name = LoopTests;
+			packageProductDependencies = (
+			);
+			productName = LoopTests;
+			productReference = 2ACE2DE93043A6F600C4FECB /* LoopTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		A8E59C34297F5E9A0064D4BA /* Loop */ = {
 			isa = PBXNativeTarget;
@@ -272,11 +313,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2620;
+				LastSwiftUpdateCheck = 2700;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					2A8689062F809625005B521B = {
 						CreatedOnToolsVersion = 26.4;
+					};
+					2ACE2DE83043A6F600C4FECB = {
+						CreatedOnToolsVersion = 27.0;
+						TestTargetID = A8E59C34297F5E9A0064D4BA;
 					};
 					A8E59C34297F5E9A0064D4BA = {
 						CreatedOnToolsVersion = 14.2;
@@ -320,12 +365,20 @@
 				A8E59C34297F5E9A0064D4BA /* Loop */,
 				B1AA00112F30000100AABBCC /* LoopUpdaterHelper */,
 				2A8689062F809625005B521B /* LoopDockTile */,
+				2ACE2DE83043A6F600C4FECB /* LoopTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		2A8689052F809625005B521B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2ACE2DE73043A6F600C4FECB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -356,6 +409,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2ACE2DE53043A6F600C4FECB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A8E59C31297F5E9A0064D4BA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -377,6 +437,11 @@
 			isa = PBXTargetDependency;
 			target = 2A8689062F809625005B521B /* LoopDockTile */;
 			targetProxy = 2A8689102F809800005B521B /* PBXContainerItemProxy */;
+		};
+		2ACE2DEE3043A6F600C4FECB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A8E59C34297F5E9A0064D4BA /* Loop */;
+			targetProxy = 2ACE2DED3043A6F600C4FECB /* PBXContainerItemProxy */;
 		};
 		B1AA00712F30000100AABBCC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -556,6 +621,77 @@
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
 				);
+			};
+			name = Development;
+		};
+		2ACE2DF03043A6F600C4FECB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5F967GYF84;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MrKai77.LoopTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Loop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Loop";
+			};
+			name = Debug;
+		};
+		2ACE2DF13043A6F600C4FECB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5F967GYF84;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MrKai77.LoopTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Loop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Loop";
+			};
+			name = Release;
+		};
+		2ACE2DF23043A6F600C4FECB /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5F967GYF84;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MrKai77.LoopTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Loop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Loop";
 			};
 			name = Development;
 		};
@@ -873,6 +1009,16 @@
 				2A8689092F809625005B521B /* Debug */,
 				2A86890A2F809625005B521B /* Release */,
 				2A86890B2F809625005B521B /* Development */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2ACE2DEF3043A6F600C4FECB /* Build configuration list for PBXNativeTarget "LoopTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2ACE2DF03043A6F600C4FECB /* Debug */,
+				2ACE2DF13043A6F600C4FECB /* Release */,
+				2ACE2DF23043A6F600C4FECB /* Development */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Loop.xcodeproj/xcshareddata/xcschemes/Loop (GH ACTIONS).xcscheme
+++ b/Loop.xcodeproj/xcshareddata/xcschemes/Loop (GH ACTIONS).xcscheme
@@ -23,11 +23,21 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2ACE2DE83043A6F600C4FECB"
+               BuildableName = "LoopTests.xctest"
+               ReferencedContainer = "container:Loop.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Loop.xcodeproj/xcshareddata/xcschemes/Loop (GH ACTIONS).xcscheme
+++ b/Loop.xcodeproj/xcshareddata/xcschemes/Loop (GH ACTIONS).xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/Loop.xcodeproj/xcshareddata/xcschemes/Loop.xcscheme
+++ b/Loop.xcodeproj/xcshareddata/xcschemes/Loop.xcscheme
@@ -61,11 +61,21 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2ACE2DE83043A6F600C4FECB"
+               BuildableName = "LoopTests.xctest"
+               ReferencedContainer = "container:Loop.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -537,7 +537,7 @@ extension LoopManager {
             whenEnabled: Defaults[.cycleModeRestartEnabled],
             currentAction: resizeContext.action,
             currentParentAction: resizeContext.parentAction,
-            previousParentAction: resizeContext.previousParentAction,
+            keybindSequenceOriginAction: resizeContext.keybindSequenceOriginAction,
             in: action
         )
         let seedAction: WindowAction? = if restartAtBeginning {

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -489,16 +489,13 @@ extension LoopManager {
             indicatorService.openAndUpdate(context: resizeContext)
 
             Task { [weak self, originatingContext] in
-                if !Defaults[.previewVisibility] {
-                    _ = try? await WindowActionEngine.shared.apply(context: originatingContext)
-                }
-
                 // If the action is to focus a window in a specific direction, find and activate that window
                 // This can work even without a current window (navigates from screen center)
                 if newAction.direction.willFocusWindow {
-                    let result = try? await WindowActionEngine.shared.apply(context: originatingContext)
-
-                    if let newTargetWindow = result?.newTargetWindow {
+                    if let newTargetWindow = WindowActionEngine.shared.resolveFocusTarget(
+                        newAction,
+                        currentWindow: originatingContext.window
+                    ) {
                         let preparedTarget = await ResizeContext.prepareWindowTarget(newTargetWindow)
 
                         guard let self,
@@ -510,7 +507,11 @@ extension LoopManager {
                         }
 
                         originatingContext.commitWindowTarget(preparedTarget)
+                        log.info("Focusing window: \(newTargetWindow.description)")
+                        newTargetWindow.focus()
                     }
+                } else if !Defaults[.previewVisibility] {
+                    _ = try? await WindowActionEngine.shared.apply(context: originatingContext)
                 }
             }
 

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -184,6 +184,7 @@ extension LoopManager {
             return
         }
 
+        actionRevision += 1
         isLoopOpening = true
         pendingOpeningAction = nil
         shouldCancelOpening = false
@@ -211,7 +212,6 @@ extension LoopManager {
             .zero
         }
 
-        actionRevision += 1
         resizeContext = ResizeContext(
             window: window,
             initialFrame: initialFrame,
@@ -236,7 +236,9 @@ extension LoopManager {
     }
 
     private func closeLoop(forceClose: Bool) async {
-        actionRevision += 1
+        if forceClose {
+            actionRevision += 1
+        }
 
         if isLoopOpening {
             shouldCancelOpening = true
@@ -324,22 +326,11 @@ extension LoopManager {
 
         if newAction.direction == .cycle {
             newParentAction = newAction
-
-            // The ability to advance a cycle is only available when the action is triggered via a keybind or a left click on the mouse.
-            // This should be set to false when the mouse is moved to prevent rapid cycling.
-            if canAdvanceCycle {
-                cycleProposal = proposeNextCycleAction(newAction)
-                newAction = cycleProposal?.action ?? newAction
-            } else {
-                if let cycle = newAction.cycle, !cycle.contains(resizeContext.action) {
-                    newAction = cycle.first ?? .init(.noAction)
-                } else {
-                    newAction = resizeContext.action
-                }
-
-                if newAction == resizeContext.action {
-                    return
-                }
+            cycleProposal = proposeCycleAction(newAction, canAdvance: canAdvanceCycle)
+            if let cycleProposal {
+                newAction = cycleProposal.action
+            } else if !canAdvanceCycle {
+                newAction = .init(.noAction)
             }
 
             // Prevents an endless loop of cycling screens. example: when a cycle only consists of:
@@ -364,10 +355,14 @@ extension LoopManager {
 
             if cycleProposal != nil,
                newAction == resizeContext.action,
-               !newAction.direction.willChangeScreen,
-               !newAction.canRepeat,
+               !canAdvanceCycle || (
+                   !newAction.direction.willChangeScreen &&
+                       !newAction.canRepeat
+               ),
                let newParentAction {
-                setResizeAction(to: resizeContext.action, parent: newParentAction)
+                if resizeContext.parentAction != newParentAction {
+                    setResizeAction(to: resizeContext.action, parent: newParentAction)
+                }
                 return
             }
         } else {
@@ -492,14 +487,13 @@ extension LoopManager {
                 // If the action is to focus a window in a specific direction, find and activate that window
                 // This can work even without a current window (navigates from screen center)
                 if newAction.direction.willFocusWindow {
-                    if let newTargetWindow = WindowActionEngine.shared.resolveFocusTarget(
+                    if let newTargetWindow = await WindowActionEngine.shared.resolveFocusTarget(
                         newAction,
                         currentWindow: originatingContext.window
                     ) {
                         let preparedTarget = await ResizeContext.prepareWindowTarget(newTargetWindow)
 
                         guard let self,
-                              isLoopActive,
                               resizeContext === originatingContext,
                               actionRevision == originatingRevision
                         else {
@@ -519,8 +513,9 @@ extension LoopManager {
         }
     }
 
-    private func proposeNextCycleAction(
-        _ action: WindowAction
+    private func proposeCycleAction(
+        _ action: WindowAction,
+        canAdvance: Bool
     ) -> CycleActionCoordinator.Proposal? {
         // Allow cycling backwards only if:
         // - Shift is not part of the action's keybind (eligibleForReverseCycle)
@@ -530,11 +525,18 @@ extension LoopManager {
             && Defaults[.triggerKey].contains(.kVK_Shift) == false
             && Defaults[.cycleBackwardsOnShiftPressed]
 
-        let shouldCycleBackwards = allowReverseCycle && keybindTrigger.effectiveEventFlags.contains(.maskShift)
+        let mode: CycleActionCoordinator.SelectionMode = if canAdvance {
+            allowReverseCycle && keybindTrigger.effectiveEventFlags.contains(.maskShift)
+                ? .advance(.backward)
+                : .advance(.forward)
+        } else {
+            .selectCurrent
+        }
+
         return resizeContext.proposeCycleAction(
             in: action,
             restartAtBeginningWhenInterrupted: Defaults[.cycleModeRestartEnabled],
-            direction: shouldCycleBackwards ? .backward : .forward
+            mode: mode
         )
     }
 

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -145,7 +145,6 @@ final class LoopManager {
         shouldCancelOpening = false
         isLoopActive = false
         hasParentCycleActionMirror.withLock { $0 = false }
-        resizeContext.resetCycleProgress()
     }
 }
 

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -31,6 +31,7 @@ final class LoopManager {
     private var isLoopOpening: Bool = false
     private var pendingOpeningAction: WindowAction?
     private var shouldCancelOpening: Bool = false
+    private var actionGeneration: UInt64 = 0
 
     private(set) var isLoopActive: Bool = false {
         didSet {
@@ -127,6 +128,8 @@ final class LoopManager {
     }
 
     func shutdown() {
+        invalidatePendingActionResults()
+
         accessibilityCheckerTask?.cancel()
         accessibilityCheckerTask = nil
 
@@ -142,6 +145,7 @@ final class LoopManager {
         shouldCancelOpening = false
         isLoopActive = false
         hasParentCycleActionMirror.withLock { $0 = false }
+        resizeContext.resetCycleProgress()
     }
 }
 
@@ -208,6 +212,7 @@ extension LoopManager {
             .zero
         }
 
+        invalidatePendingActionResults()
         resizeContext = ResizeContext(
             window: window,
             initialFrame: initialFrame,
@@ -232,6 +237,8 @@ extension LoopManager {
     }
 
     private func closeLoop(forceClose: Bool) async {
+        invalidatePendingActionResults()
+
         if isLoopOpening {
             shouldCancelOpening = true
         }
@@ -285,26 +292,32 @@ extension LoopManager {
         disableHapticFeedback: Bool = false,
         canAdvanceCycle: Bool = true
     ) async {
+        let originatingContext = resizeContext
+
         guard
             isLoopActive,
-            let currentScreen = resizeContext.screen ?? resolveAndStoreTargetScreen(
+            let currentScreen = originatingContext.screen ?? resolveAndStoreTargetScreen(
                 action: newAction,
-                window: resizeContext.window
+                window: originatingContext.window
             )
         else {
             return
         }
 
         if StashManager.shared.handleIfStashed(newAction, screen: currentScreen) {
+            invalidatePendingActionResults()
             return
         }
 
-        guard resizeContext.action.id != newAction.id || newAction.canRepeat else {
+        guard originatingContext.action.id != newAction.id || newAction.canRepeat else {
             return
         }
+
+        let originatingGeneration = beginActionGeneration()
 
         var newAction: WindowAction = newAction
         var newParentAction: WindowAction? = nil
+        var cycleSelection: CycleProgressStore.Selection?
 
         triggerKeyTimeoutTimer.cancel()
         triggerKeyTimeoutTimer.start()
@@ -315,7 +328,9 @@ extension LoopManager {
             // The ability to advance a cycle is only available when the action is triggered via a keybind or a left click on the mouse.
             // This should be set to false when the mouse is moved to prevent rapid cycling.
             if canAdvanceCycle {
-                newAction = await getNextCycleAction(newAction)
+                let nextCycleAction = getNextCycleAction(newAction)
+                newAction = nextCycleAction.action
+                cycleSelection = nextCycleAction.selection
             } else {
                 if let cycle = newAction.cycle, !cycle.contains(resizeContext.action) {
                     newAction = cycle.first ?? .init(.noAction)
@@ -333,6 +348,22 @@ extension LoopManager {
             // 2. previous screen
             if triggeredFromScreenChange, newAction.direction.willChangeScreen {
                 performHapticFeedback()
+                return
+            }
+
+            // Accept before the screen or target changes, even if the child is already current
+            if let cycleSelection,
+               let newParentAction,
+               !resizeContext.acceptCycleSelection(cycleSelection, in: newParentAction) {
+                return
+            }
+
+            if cycleSelection != nil,
+               newAction == resizeContext.action,
+               !newAction.direction.willChangeScreen,
+               !newAction.canRepeat,
+               let newParentAction {
+                setResizeAction(to: resizeContext.action, parent: newParentAction)
                 return
             }
         } else {
@@ -441,11 +472,11 @@ extension LoopManager {
             return
         }
 
-        if !disableHapticFeedback {
-            performHapticFeedback()
-        }
-
         if newAction != resizeContext.action || newAction.canRepeat {
+            if !disableHapticFeedback {
+                performHapticFeedback()
+            }
+
             let previousActionWasNoOp = resizeContext.action.direction.isNoOp
             setResizeAction(to: newAction, parent: newParentAction)
             if !Defaults[.previewVisibility], !previousActionWasNoOp {
@@ -453,18 +484,29 @@ extension LoopManager {
             }
             indicatorService.openAndUpdate(context: resizeContext)
 
-            Task {
+            Task { [weak self, originatingContext] in
                 if !Defaults[.previewVisibility] {
-                    _ = try await WindowActionEngine.shared.apply(context: resizeContext)
+                    _ = try? await WindowActionEngine.shared.apply(context: originatingContext)
                 }
 
                 // If the action is to focus a window in a specific direction, find and activate that window
                 // This can work even without a current window (navigates from screen center)
                 if newAction.direction.willFocusWindow {
-                    let result = try await WindowActionEngine.shared.apply(context: resizeContext)
+                    let result = try? await WindowActionEngine.shared.apply(context: originatingContext)
 
-                    if let newTargetWindow = result.newTargetWindow {
-                        resizeContext.setWindow(to: newTargetWindow)
+                    if let newTargetWindow = result?.newTargetWindow {
+                        let preparedTarget = await ResizeContext.prepareWindowTarget(newTargetWindow)
+
+                        guard let self,
+                              canCommitPreparedTarget(
+                                  to: originatingContext,
+                                  generation: originatingGeneration
+                              )
+                        else {
+                            return
+                        }
+
+                        originatingContext.commitWindowTarget(preparedTarget)
                     }
                 }
             }
@@ -473,10 +515,12 @@ extension LoopManager {
         }
     }
 
-    private func getNextCycleAction(_ action: WindowAction) async -> WindowAction {
+    private func getNextCycleAction(
+        _ action: WindowAction
+    ) -> (action: WindowAction, selection: CycleProgressStore.Selection?) {
         // `currentCycle[0]` below would trap on an empty cycle.
         guard let currentCycle = action.cycle, !currentCycle.isEmpty else {
-            return action
+            return (action, nil)
         }
 
         // Allow cycling backwards only if:
@@ -488,40 +532,29 @@ extension LoopManager {
             && Defaults[.cycleBackwardsOnShiftPressed]
 
         let shouldCycleBackwards = allowReverseCycle && keybindTrigger.effectiveEventFlags.contains(.maskShift)
-        var currentIndex: Int? = nil
-
-        if Defaults[.cycleModeRestartEnabled],
-           resizeContext.action.direction == .noSelection || !currentCycle.contains(resizeContext.action) {
-            return currentCycle[0]
-        }
-
-        // If the current action is noSelection, we can preserve the index from the last action.
-        // This would initially be done by reading the window's records, then would continue by finding the next index from the currentAction.
-        if resizeContext.action.direction == .noSelection,
-           !currentCycle.contains(resizeContext.action),
-           let window = resizeContext.window,
-           let latestRecord = await WindowRecords.shared.getCurrentAction(for: window) {
-            currentIndex = currentCycle.firstIndex(of: latestRecord)
+        let currentActionBelongsToCycle = currentCycle.contains { $0.id == resizeContext.action.id }
+        let restartAtBeginning = Defaults[.cycleModeRestartEnabled]
+            && (resizeContext.action.direction == .noSelection || !currentActionBelongsToCycle)
+        let seedAction: WindowAction? = if restartAtBeginning {
+            nil
+        } else if currentActionBelongsToCycle {
+            resizeContext.action
         } else {
-            currentIndex = currentCycle.firstIndex(of: resizeContext.action)
+            resizeContext.resolvedRecord?.currentAction
         }
 
-        guard var nextIndex = currentIndex else {
-            return currentCycle[0]
+        let selection = resizeContext.proposeCycleSelection(
+            in: action,
+            seededBy: seedAction,
+            restartAtBeginning: restartAtBeginning,
+            direction: shouldCycleBackwards ? .backward : .forward
+        )
+
+        guard let selection else {
+            return (action, nil)
         }
 
-        nextIndex += shouldCycleBackwards ? -1 : 1
-
-        // Wrap around the cycle index if we've reached the end or gone before the start.
-        if nextIndex >= currentCycle.count {
-            nextIndex = 0
-        }
-
-        if nextIndex < 0 {
-            nextIndex = currentCycle.count - 1
-        }
-
-        return currentCycle[nextIndex]
+        return (selection.action, selection)
     }
 
     private func performHapticFeedback() {
@@ -533,6 +566,20 @@ extension LoopManager {
     private func setResizeAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {
         resizeContext.setAction(to: newAction, parent: newParentAction)
         hasParentCycleActionMirror.withLock { $0 = newParentAction != nil }
+    }
+
+    @discardableResult
+    private func beginActionGeneration() -> UInt64 {
+        actionGeneration &+= 1
+        return actionGeneration
+    }
+
+    private func invalidatePendingActionResults() {
+        actionGeneration &+= 1
+    }
+
+    private func canCommitPreparedTarget(to context: ResizeContext, generation: UInt64) -> Bool {
+        isLoopActive && resizeContext === context && actionGeneration == generation
     }
 
     /// Resolves the target screen for `screenToResizeOn`.

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -31,7 +31,7 @@ final class LoopManager {
     private var isLoopOpening: Bool = false
     private var pendingOpeningAction: WindowAction?
     private var shouldCancelOpening: Bool = false
-    private var actionGeneration: UInt64 = 0
+    private var actionRevision: UInt64 = 0
 
     private(set) var isLoopActive: Bool = false {
         didSet {
@@ -128,7 +128,7 @@ final class LoopManager {
     }
 
     func shutdown() {
-        invalidatePendingActionResults()
+        actionRevision += 1
 
         accessibilityCheckerTask?.cancel()
         accessibilityCheckerTask = nil
@@ -212,7 +212,7 @@ extension LoopManager {
             .zero
         }
 
-        invalidatePendingActionResults()
+        actionRevision += 1
         resizeContext = ResizeContext(
             window: window,
             initialFrame: initialFrame,
@@ -237,7 +237,7 @@ extension LoopManager {
     }
 
     private func closeLoop(forceClose: Bool) async {
-        invalidatePendingActionResults()
+        actionRevision += 1
 
         if isLoopOpening {
             shouldCancelOpening = true
@@ -305,7 +305,7 @@ extension LoopManager {
         }
 
         if StashManager.shared.handleIfStashed(newAction, screen: currentScreen) {
-            invalidatePendingActionResults()
+            actionRevision += 1
             return
         }
 
@@ -313,11 +313,12 @@ extension LoopManager {
             return
         }
 
-        let originatingGeneration = beginActionGeneration()
+        actionRevision += 1
+        let originatingRevision = actionRevision
 
         var newAction: WindowAction = newAction
         var newParentAction: WindowAction? = nil
-        var cycleSelection: CycleProgressStore.Selection?
+        var cycleProposal: CycleActionCoordinator.Proposal?
 
         triggerKeyTimeoutTimer.cancel()
         triggerKeyTimeoutTimer.start()
@@ -328,9 +329,8 @@ extension LoopManager {
             // The ability to advance a cycle is only available when the action is triggered via a keybind or a left click on the mouse.
             // This should be set to false when the mouse is moved to prevent rapid cycling.
             if canAdvanceCycle {
-                let nextCycleAction = getNextCycleAction(newAction)
-                newAction = nextCycleAction.action
-                cycleSelection = nextCycleAction.selection
+                cycleProposal = proposeNextCycleAction(newAction)
+                newAction = cycleProposal?.action ?? newAction
             } else {
                 if let cycle = newAction.cycle, !cycle.contains(resizeContext.action) {
                     newAction = cycle.first ?? .init(.noAction)
@@ -351,14 +351,19 @@ extension LoopManager {
                 return
             }
 
-            // Accept before the screen or target changes, even if the child is already current
-            if let cycleSelection,
-               let newParentAction,
-               !resizeContext.acceptCycleSelection(cycleSelection, in: newParentAction) {
-                return
+            // Commit before the screen or target changes, even if the child is already current
+            if let cycleProposal, let newParentAction {
+                guard let committedAction = resizeContext.commitCycleAction(
+                    cycleProposal,
+                    in: newParentAction
+                ) else {
+                    return
+                }
+
+                newAction = committedAction
             }
 
-            if cycleSelection != nil,
+            if cycleProposal != nil,
                newAction == resizeContext.action,
                !newAction.direction.willChangeScreen,
                !newAction.canRepeat,
@@ -498,10 +503,9 @@ extension LoopManager {
                         let preparedTarget = await ResizeContext.prepareWindowTarget(newTargetWindow)
 
                         guard let self,
-                              canCommitPreparedTarget(
-                                  to: originatingContext,
-                                  generation: originatingGeneration
-                              )
+                              isLoopActive,
+                              resizeContext === originatingContext,
+                              actionRevision == originatingRevision
                         else {
                             return
                         }
@@ -515,14 +519,9 @@ extension LoopManager {
         }
     }
 
-    private func getNextCycleAction(
+    private func proposeNextCycleAction(
         _ action: WindowAction
-    ) -> (action: WindowAction, selection: CycleProgressStore.Selection?) {
-        // `currentCycle[0]` below would trap on an empty cycle.
-        guard let currentCycle = action.cycle, !currentCycle.isEmpty else {
-            return (action, nil)
-        }
-
+    ) -> CycleActionCoordinator.Proposal? {
         // Allow cycling backwards only if:
         // - Shift is not part of the action's keybind (eligibleForReverseCycle)
         // - Shift is not part of the trigger key
@@ -532,34 +531,11 @@ extension LoopManager {
             && Defaults[.cycleBackwardsOnShiftPressed]
 
         let shouldCycleBackwards = allowReverseCycle && keybindTrigger.effectiveEventFlags.contains(.maskShift)
-        let currentActionBelongsToCycle = currentCycle.contains { $0.id == resizeContext.action.id }
-        let restartAtBeginning = CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: Defaults[.cycleModeRestartEnabled],
-            currentAction: resizeContext.action,
-            currentParentAction: resizeContext.parentAction,
-            keybindSequenceOriginAction: resizeContext.keybindSequenceOriginAction,
-            in: action
-        )
-        let seedAction: WindowAction? = if restartAtBeginning {
-            nil
-        } else if currentActionBelongsToCycle {
-            resizeContext.action
-        } else {
-            resizeContext.resolvedRecord?.currentAction
-        }
-
-        let selection = resizeContext.proposeCycleSelection(
+        return resizeContext.proposeCycleAction(
             in: action,
-            seededBy: seedAction,
-            restartAtBeginning: restartAtBeginning,
+            restartAtBeginningWhenInterrupted: Defaults[.cycleModeRestartEnabled],
             direction: shouldCycleBackwards ? .backward : .forward
         )
-
-        guard let selection else {
-            return (action, nil)
-        }
-
-        return (selection.action, selection)
     }
 
     private func performHapticFeedback() {
@@ -571,20 +547,6 @@ extension LoopManager {
     private func setResizeAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {
         resizeContext.setAction(to: newAction, parent: newParentAction)
         hasParentCycleActionMirror.withLock { $0 = newParentAction != nil }
-    }
-
-    @discardableResult
-    private func beginActionGeneration() -> UInt64 {
-        actionGeneration &+= 1
-        return actionGeneration
-    }
-
-    private func invalidatePendingActionResults() {
-        actionGeneration &+= 1
-    }
-
-    private func canCommitPreparedTarget(to context: ResizeContext, generation: UInt64) -> Bool {
-        isLoopActive && resizeContext === context && actionGeneration == generation
     }
 
     /// Resolves the target screen for `screenToResizeOn`.

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -533,8 +533,13 @@ extension LoopManager {
 
         let shouldCycleBackwards = allowReverseCycle && keybindTrigger.effectiveEventFlags.contains(.maskShift)
         let currentActionBelongsToCycle = currentCycle.contains { $0.id == resizeContext.action.id }
-        let restartAtBeginning = Defaults[.cycleModeRestartEnabled]
-            && (resizeContext.action.direction == .noSelection || !currentActionBelongsToCycle)
+        let restartAtBeginning = CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: Defaults[.cycleModeRestartEnabled],
+            currentAction: resizeContext.action,
+            currentParentAction: resizeContext.parentAction,
+            previousParentAction: resizeContext.previousParentAction,
+            in: action
+        )
         let seedAction: WindowAction? = if restartAtBeginning {
             nil
         } else if currentActionBelongsToCycle {

--- a/Loop/Core/Observers/Helpers/KeybindResolver.swift
+++ b/Loop/Core/Observers/Helpers/KeybindResolver.swift
@@ -1,0 +1,231 @@
+//
+//  KeybindResolver.swift
+//  Loop
+//
+//  Created by Kai Azim on 2026-08-28.
+//
+
+import CoreGraphics
+
+/// Matches keyboard events without mutating `KeybindTrigger` state
+enum KeybindResolver {
+    enum EventType {
+        case keyDown
+        case keyUp
+        case flagsChanged
+    }
+
+    struct TriggerConfiguration {
+        let keys: Set<CGKeyCode>
+        let isSideDependent: Bool
+
+        var normalizedKeys: Set<CGKeyCode> {
+            isSideDependent ? keys : keys.baseModifiers
+        }
+    }
+
+    struct Input {
+        let eventType: EventType
+        let isRepeat: Bool
+        let pressedKeys: Set<CGKeyCode>
+        let modifierKeys: Set<CGKeyCode>
+        let trigger: TriggerConfiguration
+        let isLoopOpen: Bool
+        let actionsByKeybind: [Set<CGKeyCode>: WindowAction]
+        let bypassedActionsByKeybind: [Set<CGKeyCode>: WindowAction]
+    }
+
+    enum ActionSource {
+        case trigger
+        case bypassTrigger
+    }
+
+    enum ActionCategory {
+        case cycle
+        case repeatableNonCycle
+        case nonRepeatable
+
+        init(action: WindowAction) {
+            if action.direction == .cycle {
+                self = .cycle
+            } else if action.canRepeat {
+                self = .repeatableNonCycle
+            } else {
+                self = .nonRepeatable
+            }
+        }
+
+        fileprivate var canActivateOnRepeat: Bool {
+            self == .repeatableNonCycle
+        }
+    }
+
+    enum Activation {
+        case activate
+        case suppressAutorepeat
+    }
+
+    enum Match {
+        case none
+        case escape
+        case triggerReleasedWhileOpen
+        case triggerOnly
+        case action(
+            WindowAction,
+            source: ActionSource,
+            category: ActionCategory,
+            activation: Activation
+        )
+    }
+
+    enum Effect {
+        case none
+        case open(
+            action: WindowAction,
+            overrideExistingTriggerDelayAction: Bool
+        )
+        case close(
+            force: Bool,
+            notifyDoubleClickKeyUp: Bool
+        )
+    }
+
+    enum HandlingIntent {
+        case forward
+        case consume
+        case opening
+
+        case consumeIfLoopOpenOtherwiseOpening
+
+        func resolve(isLoopOpenAfterEffect: Bool) -> ResolvedHandling {
+            switch self {
+            case .forward:
+                .forward
+            case .consume:
+                .consume
+            case .opening:
+                .opening
+            case .consumeIfLoopOpenOtherwiseOpening:
+                isLoopOpenAfterEffect ? .consume : .opening
+            }
+        }
+    }
+
+    enum ResolvedHandling {
+        case forward
+        case consume
+        case opening
+    }
+
+    struct Decision {
+        let match: Match
+        let effect: Effect
+        let handling: HandlingIntent
+    }
+
+    /// Resolves an event using eager, exact key matching.
+    ///
+    /// Key-up events never match actions, so releasing a chord cannot trigger its subset.
+    static func resolve(_ input: Input) -> Decision {
+        let modifierKeys = input.trigger.isSideDependent
+            ? input.modifierKeys
+            : input.modifierKeys.baseModifiers
+        let allPressedKeys = input.pressedKeys.union(modifierKeys)
+        let triggerKeys = input.trigger.normalizedKeys
+        let containsTrigger = allPressedKeys.isSuperset(of: triggerKeys)
+        let actionKeys = allPressedKeys.subtracting(triggerKeys).baseModifiers
+        let allPressedKeysBaseModifiers = allPressedKeys.baseModifiers
+
+        if input.isLoopOpen {
+            if input.pressedKeys.contains(.kVK_Escape) {
+                return .init(
+                    match: .escape,
+                    effect: .close(force: true, notifyDoubleClickKeyUp: false),
+                    handling: .consume
+                )
+            }
+
+            if input.eventType == .keyUp {
+                return .init(match: .none, effect: .none, handling: .forward)
+            }
+
+            if input.eventType != .keyDown, !containsTrigger {
+                return .init(
+                    match: .triggerReleasedWhileOpen,
+                    effect: .close(force: false, notifyDoubleClickKeyUp: false),
+                    handling: .forward
+                )
+            }
+        }
+
+        guard input.eventType != .keyUp else {
+            return .init(match: .none, effect: .none, handling: .forward)
+        }
+
+        if containsTrigger {
+            if let action = input.actionsByKeybind[actionKeys] {
+                return actionDecision(
+                    action,
+                    source: .trigger,
+                    isRepeat: input.isRepeat
+                )
+            }
+
+            if allPressedKeys == triggerKeys {
+                return .init(
+                    match: .triggerOnly,
+                    effect: .open(
+                        action: .init(.noSelection),
+                        overrideExistingTriggerDelayAction: !input.isRepeat
+                    ),
+                    handling: .opening
+                )
+            }
+        } else if let action = input.bypassedActionsByKeybind[allPressedKeysBaseModifiers] {
+            return actionDecision(
+                action,
+                source: .bypassTrigger,
+                isRepeat: input.isRepeat
+            )
+        } else {
+            return .init(
+                match: .none,
+                effect: .close(
+                    force: false,
+                    notifyDoubleClickKeyUp: allPressedKeys.isEmpty
+                ),
+                handling: .forward
+            )
+        }
+
+        return .init(match: .none, effect: .none, handling: .forward)
+    }
+
+    private static func actionDecision(
+        _ action: WindowAction,
+        source: ActionSource,
+        isRepeat: Bool
+    ) -> Decision {
+        let category = ActionCategory(action: action)
+        let activation: Activation = !isRepeat || category.canActivateOnRepeat
+            ? .activate
+            : .suppressAutorepeat
+        let effect: Effect = switch activation {
+        case .activate:
+            .open(action: action, overrideExistingTriggerDelayAction: true)
+        case .suppressAutorepeat:
+            .none
+        }
+
+        return .init(
+            match: .action(
+                action,
+                source: source,
+                category: category,
+                activation: activation
+            ),
+            effect: effect,
+            handling: .consumeIfLoopOpenOtherwiseOpening
+        )
+    }
+}

--- a/Loop/Core/Observers/Helpers/KeybindResolver.swift
+++ b/Loop/Core/Observers/Helpers/KeybindResolver.swift
@@ -65,7 +65,7 @@ enum KeybindResolver {
         case suppressAutorepeat
     }
 
-    enum Match {
+    enum Match: Equatable {
         case none
         case escape
         case triggerReleasedWhileOpen
@@ -78,7 +78,7 @@ enum KeybindResolver {
         )
     }
 
-    enum Effect {
+    enum Effect: Equatable {
         case none
         case open(
             action: WindowAction,
@@ -90,7 +90,7 @@ enum KeybindResolver {
         )
     }
 
-    enum HandlingIntent {
+    enum HandlingIntent: Equatable {
         case forward
         case consume
         case opening
@@ -111,7 +111,7 @@ enum KeybindResolver {
         }
     }
 
-    enum ResolvedHandling {
+    enum ResolvedHandling: Equatable {
         case forward
         case consume
         case opening

--- a/Loop/Core/Observers/Helpers/KeybindResolver.swift
+++ b/Loop/Core/Observers/Helpers/KeybindResolver.swift
@@ -35,49 +35,6 @@ enum KeybindResolver {
         let bypassedActionsByKeybind: [Set<CGKeyCode>: WindowAction]
     }
 
-    enum ActionSource: Equatable {
-        case trigger
-        case bypassTrigger
-    }
-
-    enum ActionCategory: Equatable {
-        case cycle
-        case repeatableNonCycle
-        case nonRepeatable
-
-        init(action: WindowAction) {
-            if action.direction == .cycle {
-                self = .cycle
-            } else if action.canRepeat {
-                self = .repeatableNonCycle
-            } else {
-                self = .nonRepeatable
-            }
-        }
-
-        fileprivate var canActivateOnRepeat: Bool {
-            self == .repeatableNonCycle
-        }
-    }
-
-    enum Activation: Equatable {
-        case activate
-        case suppressAutorepeat
-    }
-
-    enum Match: Equatable {
-        case none
-        case escape
-        case triggerReleasedWhileOpen
-        case triggerOnly
-        case action(
-            WindowAction,
-            source: ActionSource,
-            category: ActionCategory,
-            activation: Activation
-        )
-    }
-
     enum Effect: Equatable {
         case none
         case open(
@@ -118,7 +75,6 @@ enum KeybindResolver {
     }
 
     struct Decision {
-        let match: Match
         let effect: Effect
         let handling: HandlingIntent
     }
@@ -139,19 +95,17 @@ enum KeybindResolver {
         if input.isLoopOpen {
             if input.pressedKeys.contains(.kVK_Escape) {
                 return .init(
-                    match: .escape,
                     effect: .close(force: true, notifyDoubleClickKeyUp: false),
                     handling: .consume
                 )
             }
 
             if input.eventType == .keyUp {
-                return .init(match: .none, effect: .none, handling: .forward)
+                return .init(effect: .none, handling: .forward)
             }
 
             if input.eventType != .keyDown, !containsTrigger {
                 return .init(
-                    match: .triggerReleasedWhileOpen,
                     effect: .close(force: false, notifyDoubleClickKeyUp: false),
                     handling: .forward
                 )
@@ -159,21 +113,19 @@ enum KeybindResolver {
         }
 
         guard input.eventType != .keyUp else {
-            return .init(match: .none, effect: .none, handling: .forward)
+            return .init(effect: .none, handling: .forward)
         }
 
         if containsTrigger {
             if let action = input.actionsByKeybind[actionKeys] {
                 return actionDecision(
                     action,
-                    source: .trigger,
                     isRepeat: input.isRepeat
                 )
             }
 
             if allPressedKeys == triggerKeys {
                 return .init(
-                    match: .triggerOnly,
                     effect: .open(
                         action: .init(.noSelection),
                         overrideExistingTriggerDelayAction: !input.isRepeat
@@ -184,12 +136,10 @@ enum KeybindResolver {
         } else if let action = input.bypassedActionsByKeybind[allPressedKeysBaseModifiers] {
             return actionDecision(
                 action,
-                source: .bypassTrigger,
                 isRepeat: input.isRepeat
             )
         } else {
             return .init(
-                match: .none,
                 effect: .close(
                     force: false,
                     notifyDoubleClickKeyUp: allPressedKeys.isEmpty
@@ -198,33 +148,21 @@ enum KeybindResolver {
             )
         }
 
-        return .init(match: .none, effect: .none, handling: .forward)
+        return .init(effect: .none, handling: .forward)
     }
 
     private static func actionDecision(
         _ action: WindowAction,
-        source: ActionSource,
         isRepeat: Bool
     ) -> Decision {
-        let category = ActionCategory(action: action)
-        let activation: Activation = !isRepeat || category.canActivateOnRepeat
-            ? .activate
-            : .suppressAutorepeat
-        let effect: Effect = switch activation {
-        case .activate:
-            .open(action: action, overrideExistingTriggerDelayAction: true)
-        case .suppressAutorepeat:
-            .none
-        }
+        let shouldActivate = !isRepeat || (
+            action.direction != .cycle && action.canRepeat
+        )
 
         return .init(
-            match: .action(
-                action,
-                source: source,
-                category: category,
-                activation: activation
-            ),
-            effect: effect,
+            effect: shouldActivate
+                ? .open(action: action, overrideExistingTriggerDelayAction: true)
+                : .none,
             handling: .consumeIfLoopOpenOtherwiseOpening
         )
     }

--- a/Loop/Core/Observers/Helpers/KeybindResolver.swift
+++ b/Loop/Core/Observers/Helpers/KeybindResolver.swift
@@ -35,12 +35,12 @@ enum KeybindResolver {
         let bypassedActionsByKeybind: [Set<CGKeyCode>: WindowAction]
     }
 
-    enum ActionSource {
+    enum ActionSource: Equatable {
         case trigger
         case bypassTrigger
     }
 
-    enum ActionCategory {
+    enum ActionCategory: Equatable {
         case cycle
         case repeatableNonCycle
         case nonRepeatable
@@ -60,7 +60,7 @@ enum KeybindResolver {
         }
     }
 
-    enum Activation {
+    enum Activation: Equatable {
         case activate
         case suppressAutorepeat
     }

--- a/Loop/Core/Observers/KeybindTrigger.swift
+++ b/Loop/Core/Observers/KeybindTrigger.swift
@@ -37,9 +37,6 @@ final class KeybindTrigger {
     private var useTriggerDelay: Bool { Defaults[.triggerDelay] > 0.1 }
     private var doubleClickToTrigger: Bool { Defaults[.doubleClickToTrigger] }
     private var sideDependentTriggerKey: Bool { Defaults[.sideDependentTriggerKey] }
-    private var triggerKey: Set<CGKeyCode> {
-        sideDependentTriggerKey ? Defaults[.triggerKey] : Defaults[.triggerKey].baseModifiers
-    }
 
     private lazy var triggerDelayTimer = TriggerDelayTimer(openCallback: openCallback)
     private lazy var doubleClickTimer = DoubleClickTimer { [weak self] action in
@@ -76,7 +73,7 @@ final class KeybindTrigger {
             return
         }
 
-        eventMonitor?.stop()
+        stop()
 
         let eventMonitor = ActiveEventMonitor(
             "keybind_trigger",
@@ -84,55 +81,66 @@ final class KeybindTrigger {
         ) { [weak self] event -> ActiveEventMonitor.EventHandling in
             guard let self else { return .forward }
 
-            let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
-                .baseKey(flags: .init(rawValue: UInt(event.flags.rawValue)))
-
-            var filteredFlags = event.flags
-            if keyCode.isFnSpecialKey, !effectiveEventFlags.contains(.maskSecondaryFn) {
-                filteredFlags.remove(.maskSecondaryFn)
-            }
-
-            let isLoopOpen = checkIfLoopOpen()
-            effectiveEventFlags = filteredFlags
-
-            if event.type == .keyUp {
-                pressedKeys.remove(keyCode)
-            } else if event.type == .keyDown {
-                pressedKeys.insert(keyCode)
-            }
-
-            // Special events such as the emoji key
-            if specialEventKeys.contains(keyCode) {
-                let canPassthrough = canPassthroughNextSpecialEvent
-                canPassthroughNextSpecialEvent = true // reset
-                return canPassthrough ? .forward : .ignore
-            }
-
-            // If this is a valid event, don't passthrough
-            let result = performKeybind(
-                type: event.type,
-                isARepeat: event.getIntegerValueField(.keyboardEventAutorepeat) == 1,
-                flags: filteredFlags,
-                isLoopOpen: isLoopOpen
-            )
-
-            if result == .consume {
-                log.debug("Blocked event")
-                return .ignore
-            }
-
-            // If this shouldn't consume the event, and Loop isn't in the process of opening (possibly due to trigger delays),
-            // check if it was a system keybind (ex. screenshot), and in that case, passthrough and force-close Loop
-            refreshSystemKeybindCacheIfNeeded()
-            if result != .opening, event.type == .keyDown, systemKeybindCache.contains(pressedKeys) {
-                closeLoop(forceClose: true)
-            }
-
-            return .forward
+            return handle(event)
         }
 
         eventMonitor.start()
         self.eventMonitor = eventMonitor
+    }
+
+    private func handle(_ event: CGEvent) -> ActiveEventMonitor.EventHandling {
+        let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+            .baseKey(flags: .init(rawValue: UInt(event.flags.rawValue)))
+
+        var filteredFlags = event.flags
+        if keyCode.isFnSpecialKey, !effectiveEventFlags.contains(.maskSecondaryFn) {
+            filteredFlags.remove(.maskSecondaryFn)
+        }
+
+        let isLoopOpen = checkIfLoopOpen()
+        effectiveEventFlags = filteredFlags
+
+        if event.type == .keyUp {
+            pressedKeys.remove(keyCode)
+        } else if event.type == .keyDown {
+            pressedKeys.insert(keyCode)
+        }
+
+        // Special events such as the emoji key
+        if specialEventKeys.contains(keyCode) {
+            let canPassthrough = canPassthroughNextSpecialEvent
+            canPassthroughNextSpecialEvent = true // reset
+            return canPassthrough ? .forward : .ignore
+        }
+
+        let eventType: KeybindResolver.EventType? = switch event.type {
+        case .keyDown: .keyDown
+        case .keyUp: .keyUp
+        case .flagsChanged: .flagsChanged
+        default: nil
+        }
+        guard let eventType else { return .forward }
+
+        let result = performKeybind(
+            type: eventType,
+            isARepeat: event.getIntegerValueField(.keyboardEventAutorepeat) == 1,
+            flags: filteredFlags,
+            isLoopOpen: isLoopOpen
+        )
+
+        if result == .consume {
+            log.debug("Blocked event")
+            return .ignore
+        }
+
+        // If this shouldn't consume the event, and Loop isn't in the process of opening (possibly due to trigger delays),
+        // check if it was a system keybind (ex. screenshot), and in that case, passthrough and force-close Loop
+        refreshSystemKeybindCacheIfNeeded()
+        if result != .opening, event.type == .keyDown, systemKeybindCache.contains(pressedKeys) {
+            closeLoop(forceClose: true)
+        }
+
+        return .forward
     }
 
     func stop() {
@@ -141,6 +149,7 @@ final class KeybindTrigger {
 
         // Reset states
         pressedKeys = []
+        effectiveEventFlags = []
         canPassthroughNextSpecialEvent = true
     }
 
@@ -157,68 +166,53 @@ final class KeybindTrigger {
     ///   - flags: modifier flags associated with this event.
     ///   - isLoopOpen: whether Loop is currently open.
     /// - Returns: whether this event was processed by Loop.
-    private func performKeybind(type: CGEventType, isARepeat: Bool, flags: CGEventFlags, isLoopOpen: Bool) -> PerformKeybindResult {
-        let flagKeys = sideDependentTriggerKey ? flags.keyCodes : flags.keyCodes.baseModifiers
-        let allPressedKeys: Set<CGKeyCode> = pressedKeys.union(flagKeys)
+    private func performKeybind(
+        type: KeybindResolver.EventType,
+        isARepeat: Bool,
+        flags: CGEventFlags,
+        isLoopOpen: Bool
+    ) -> PerformKeybindResult {
+        let decision = KeybindResolver.resolve(
+            .init(
+                eventType: type,
+                isRepeat: isARepeat,
+                pressedKeys: pressedKeys,
+                modifierKeys: flags.keyCodes,
+                trigger: .init(
+                    keys: Defaults[.triggerKey],
+                    isSideDependent: sideDependentTriggerKey
+                ),
+                isLoopOpen: isLoopOpen,
+                actionsByKeybind: windowActionCache.actionsByKeybind,
+                bypassedActionsByKeybind: windowActionCache.bypassedActionsByKeybind
+            )
+        )
 
-        let containsTrigger = allPressedKeys.isSuperset(of: triggerKey)
-        let actionKeys: Set<CGKeyCode> = Set(allPressedKeys.subtracting(triggerKey).map(\.baseModifier))
-        let allPressedKeysBaseModifiers: Set<CGKeyCode> = Set(allPressedKeys.map(\.baseModifier))
-
-        if isLoopOpen {
-            if pressedKeys.contains(.kVK_Escape) {
-                closeLoop(forceClose: true)
-                return .consume
+        switch decision.effect {
+        case .none:
+            break
+        case let .open(action, overrideExistingTriggerDelayAction):
+            openLoop(
+                startingAction: action,
+                overrideExistingTriggerDelayTimerAction: overrideExistingTriggerDelayAction
+            )
+        case let .close(force, notifyDoubleClickKeyUp):
+            if notifyDoubleClickKeyUp {
+                doubleClickTimer.handleKeyUp()
             }
-
-            if type == .keyUp {
-                return .forward
-            }
-
-            if type != .keyDown, !containsTrigger {
-                closeLoop(forceClose: false)
-                return .forward
-            }
+            closeLoop(forceClose: force)
         }
 
-        if type != .keyUp { // keyDown for flagsChanged
-            if containsTrigger {
-                // Try an match directly with the action keys first, then fallback to just the key code.
-                // This prevents failures when the user is tapping the keys in rapid succession.
-                if let action = windowActionCache.actionsByKeybind[actionKeys] {
-                    if !isARepeat || action.canRepeat {
-                        openLoop(startingAction: action, overrideExistingTriggerDelayTimerAction: true)
-                    }
-
-                    // Only consume the event if the last command actually opened Loop.
-                    // The main reason Loop *wouldn't* open after an `openLoop` call would be because the user has enabled a trigger delay.
-                    return checkIfLoopOpen() ? .consume : .opening
-                }
-
-                // Only trigger Loop without an action if the only pressed keys perfectly matches the trigger key.
-                if allPressedKeys == triggerKey {
-                    openLoop(
-                        startingAction: .init(.noSelection),
-                        overrideExistingTriggerDelayTimerAction: !isARepeat
-                    )
-                    return .opening
-                }
-            } else if let bypassedAction = windowActionCache.bypassedActionsByKeybind[allPressedKeysBaseModifiers] {
-                if !isARepeat || bypassedAction.canRepeat {
-                    openLoop(startingAction: bypassedAction, overrideExistingTriggerDelayTimerAction: true)
-                }
-
-                return checkIfLoopOpen() ? .consume : .opening
-            } else {
-                if allPressedKeys.isEmpty {
-                    doubleClickTimer.handleKeyUp()
-                }
-                closeLoop(forceClose: false)
-            }
+        return switch decision.handling {
+        case .forward:
+            .forward
+        case .consume:
+            .consume
+        case .opening:
+            .opening
+        case .consumeIfLoopOpenOtherwiseOpening:
+            checkIfLoopOpen() ? .consume : .opening
         }
-
-        // If this wasn't a valid keybind, return false, which will then forward the key event to the frontmost app
-        return .forward
     }
 
     private func openLoop(startingAction: WindowAction, overrideExistingTriggerDelayTimerAction: Bool) {
@@ -242,6 +236,7 @@ final class KeybindTrigger {
         triggerDelayTimer.cancel()
         closeCallback(forceClose)
         pressedKeys = []
+        effectiveEventFlags = []
     }
 
     private func startTriggerDelayTimer(

--- a/Loop/Core/Observers/KeybindTrigger.swift
+++ b/Loop/Core/Observers/KeybindTrigger.swift
@@ -37,8 +37,8 @@ final class KeybindTrigger {
     private var useTriggerDelay: Bool { Defaults[.triggerDelay] > 0.1 }
     private var doubleClickToTrigger: Bool { Defaults[.doubleClickToTrigger] }
     private var sideDependentTriggerKey: Bool { Defaults[.sideDependentTriggerKey] }
-
     private lazy var triggerDelayTimer = TriggerDelayTimer(openCallback: openCallback)
+
     private lazy var doubleClickTimer = DoubleClickTimer { [weak self] action in
         guard let self else { return }
 
@@ -181,7 +181,6 @@ final class KeybindTrigger {
                 bypassedActionsByKeybind: windowActionCache.bypassedActionsByKeybind
             )
         )
-
         switch decision.effect {
         case .none:
             break
@@ -200,7 +199,10 @@ final class KeybindTrigger {
         return decision.handling.resolve(isLoopOpenAfterEffect: checkIfLoopOpen())
     }
 
-    private func openLoop(startingAction: WindowAction, overrideExistingTriggerDelayTimerAction: Bool) {
+    private func openLoop(
+        startingAction: WindowAction,
+        overrideExistingTriggerDelayTimerAction: Bool
+    ) {
         if checkIfLoopOpen() {
             openCallback(startingAction) // Only update Loop to the latest WindowAction
         } else {
@@ -221,7 +223,6 @@ final class KeybindTrigger {
         triggerDelayTimer.cancel()
         closeCallback(forceClose)
         pressedKeys = []
-        effectiveEventFlags = []
     }
 
     private func startTriggerDelayTimer(

--- a/Loop/Core/Observers/KeybindTrigger.swift
+++ b/Loop/Core/Observers/KeybindTrigger.swift
@@ -153,12 +153,6 @@ final class KeybindTrigger {
         canPassthroughNextSpecialEvent = true
     }
 
-    enum PerformKeybindResult {
-        case consume
-        case forward
-        case opening
-    }
-
     /// Determines if an event corresponds to a valid Loop action.
     /// - Parameters:
     ///   - type: the type of this event.
@@ -171,7 +165,7 @@ final class KeybindTrigger {
         isARepeat: Bool,
         flags: CGEventFlags,
         isLoopOpen: Bool
-    ) -> PerformKeybindResult {
+    ) -> KeybindResolver.ResolvedHandling {
         let decision = KeybindResolver.resolve(
             .init(
                 eventType: type,
@@ -203,16 +197,7 @@ final class KeybindTrigger {
             closeLoop(forceClose: force)
         }
 
-        return switch decision.handling {
-        case .forward:
-            .forward
-        case .consume:
-            .consume
-        case .opening:
-            .opening
-        case .consumeIfLoopOpenOtherwiseOpening:
-            checkIfLoopOpen() ? .consume : .opening
-        }
+        return decision.handling.resolve(isLoopOpenAfterEffect: checkIfLoopOpen())
     }
 
     private func openLoop(startingAction: WindowAction, overrideExistingTriggerDelayTimerAction: Bool) {

--- a/Loop/Window Management/Window Action/CycleActionCoordinator.swift
+++ b/Loop/Window Management/Window Action/CycleActionCoordinator.swift
@@ -1,0 +1,115 @@
+//
+//  CycleActionCoordinator.swift
+//  Loop
+//
+//  Created by Kai Azim on 2026-08-30.
+//
+
+import CoreGraphics
+
+struct CycleActionCoordinator {
+    struct Proposal {
+        let action: WindowAction
+
+        fileprivate let selection: CycleProgressStore.Selection
+    }
+
+    private var progressStore = CycleProgressStore()
+    private var keybindSequenceOriginAction: WindowAction?
+
+    mutating func proposeAction(
+        for targetWindowID: CGWindowID,
+        in cycleAction: WindowAction,
+        currentAction: WindowAction,
+        currentParentAction: WindowAction?,
+        recordedAction: WindowAction?,
+        restartAtBeginningWhenInterrupted: Bool,
+        direction: CycleProgressStore.Direction
+    ) -> Proposal? {
+        let currentActionBelongsToCycle = cycleAction.cycle?.contains {
+            $0.id == currentAction.id
+        } == true
+        let restartAtBeginning = Self.shouldRestartAtBeginning(
+            whenEnabled: restartAtBeginningWhenInterrupted,
+            currentAction: currentAction,
+            currentParentAction: currentParentAction,
+            keybindSequenceOriginAction: keybindSequenceOriginAction,
+            in: cycleAction
+        )
+        let seedAction: WindowAction? = if restartAtBeginning {
+            nil
+        } else if currentActionBelongsToCycle {
+            currentAction
+        } else {
+            recordedAction
+        }
+
+        guard let selection = progressStore.proposeSelection(
+            for: targetWindowID,
+            in: cycleAction,
+            seededBy: seedAction,
+            restartAtBeginning: restartAtBeginning,
+            direction: direction
+        ) else {
+            return nil
+        }
+
+        return Proposal(action: selection.action, selection: selection)
+    }
+
+    mutating func commit(
+        _ proposal: Proposal,
+        for targetWindowID: CGWindowID,
+        in cycleAction: WindowAction
+    ) -> WindowAction? {
+        progressStore.commit(
+            proposal.selection,
+            for: targetWindowID,
+            in: cycleAction
+        )
+    }
+
+    mutating func recordActionTransition(
+        from currentAction: WindowAction,
+        currentParentAction: WindowAction?,
+        to newAction: WindowAction,
+        newParentAction: WindowAction?
+    ) {
+        let currentBindingAction = currentParentAction ?? currentAction
+        let nextBindingAction = newParentAction ?? newAction
+        let continuesKeybindSequence = !currentBindingAction.keybind.isEmpty
+            && currentBindingAction.keybind.isStrictSubset(of: nextBindingAction.keybind)
+
+        if !continuesKeybindSequence {
+            keybindSequenceOriginAction = currentBindingAction
+        }
+    }
+
+    mutating func resetProgress(for targetWindowID: CGWindowID) {
+        progressStore.reset(for: targetWindowID)
+    }
+
+    mutating func resetProgress() {
+        progressStore.reset()
+    }
+
+    static func shouldRestartAtBeginning(
+        whenEnabled isEnabled: Bool,
+        currentAction: WindowAction,
+        currentParentAction: WindowAction?,
+        keybindSequenceOriginAction: WindowAction?,
+        in cycleAction: WindowAction
+    ) -> Bool {
+        let currentKeybind = currentParentAction?.keybind ?? currentAction.keybind
+        let isRepeatingLongerKeybind = keybindSequenceOriginAction?.id == cycleAction.id
+            && !currentKeybind.isEmpty
+            && currentKeybind.isStrictSubset(of: cycleAction.keybind)
+
+        return isEnabled && (
+            !isRepeatingLongerKeybind && (
+                currentAction.direction == .noSelection ||
+                    cycleAction.cycle?.contains { $0.id == currentAction.id } != true
+            )
+        )
+    }
+}

--- a/Loop/Window Management/Window Action/CycleActionCoordinator.swift
+++ b/Loop/Window Management/Window Action/CycleActionCoordinator.swift
@@ -8,6 +8,11 @@
 import CoreGraphics
 
 struct CycleActionCoordinator {
+    enum SelectionMode {
+        case advance(CycleProgressStore.Direction)
+        case selectCurrent
+    }
+
     struct Proposal {
         let action: WindowAction
 
@@ -24,7 +29,7 @@ struct CycleActionCoordinator {
         currentParentAction: WindowAction?,
         recordedAction: WindowAction?,
         restartAtBeginningWhenInterrupted: Bool,
-        direction: CycleProgressStore.Direction
+        mode: SelectionMode
     ) -> Proposal? {
         let currentActionBelongsToCycle = cycleAction.cycle?.contains {
             $0.id == currentAction.id
@@ -43,14 +48,24 @@ struct CycleActionCoordinator {
         } else {
             recordedAction
         }
+        let selection: CycleProgressStore.Selection? = switch mode {
+        case let .advance(direction):
+            progressStore.proposeSelection(
+                for: targetWindowID,
+                in: cycleAction,
+                seededBy: seedAction,
+                restartAtBeginning: restartAtBeginning,
+                direction: direction
+            )
+        case .selectCurrent:
+            progressStore.proposeCurrentSelection(
+                for: targetWindowID,
+                in: cycleAction,
+                seededBy: currentActionBelongsToCycle ? currentAction : nil
+            )
+        }
 
-        guard let selection = progressStore.proposeSelection(
-            for: targetWindowID,
-            in: cycleAction,
-            seededBy: seedAction,
-            restartAtBeginning: restartAtBeginning,
-            direction: direction
-        ) else {
+        guard let selection else {
             return nil
         }
 

--- a/Loop/Window Management/Window Action/CycleActionCoordinator.swift
+++ b/Loop/Window Management/Window Action/CycleActionCoordinator.swift
@@ -85,14 +85,6 @@ struct CycleActionCoordinator {
         }
     }
 
-    mutating func resetProgress(for targetWindowID: CGWindowID) {
-        progressStore.reset(for: targetWindowID)
-    }
-
-    mutating func resetProgress() {
-        progressStore.reset()
-    }
-
     static func shouldRestartAtBeginning(
         whenEnabled isEnabled: Bool,
         currentAction: WindowAction,

--- a/Loop/Window Management/Window Action/CycleProgressStore.swift
+++ b/Loop/Window Management/Window Action/CycleProgressStore.swift
@@ -1,0 +1,158 @@
+//
+//  CycleProgressStore.swift
+//  Loop
+//
+//  Created by Kai Azim on 2026-08-28.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Tracks cycle progress by target window and parent cycle
+struct CycleProgressStore {
+    enum Direction {
+        case forward
+        case backward
+    }
+
+    struct Selection {
+        let action: WindowAction
+        let index: Int
+
+        fileprivate let key: Key
+
+        fileprivate init(action: WindowAction, index: Int, key: Key) {
+            self.action = action
+            self.index = index
+            self.key = key
+        }
+    }
+
+    fileprivate struct Key: Hashable {
+        let targetWindowID: CGWindowID
+        let parentCycleActionID: UUID
+    }
+
+    /// Keeps the selected occurrence when a cycle contains duplicate children
+    private struct Cursor {
+        let childActionID: UUID
+        let lastKnownIndex: Int
+    }
+
+    private var cursors: [Key: Cursor] = [:]
+
+    /// Returns the next child without updating progress.
+    ///
+    /// Restarts at the first child when requested. Otherwise, uses stored progress before `seedAction`.
+    mutating func proposeSelection(
+        for targetWindowID: CGWindowID,
+        in cycleAction: WindowAction,
+        seededBy seedAction: WindowAction?,
+        restartAtBeginning: Bool,
+        direction: Direction
+    ) -> Selection? {
+        let key = Key(
+            targetWindowID: targetWindowID,
+            parentCycleActionID: cycleAction.id
+        )
+
+        guard cycleAction.direction == .cycle,
+              let children = cycleAction.cycle,
+              !children.isEmpty
+        else {
+            cursors[key] = nil
+            return nil
+        }
+
+        if restartAtBeginning {
+            return Selection(action: children[0], index: 0, key: key)
+        }
+
+        if let cursor = cursors[key] {
+            if let currentIndex = validatedIndex(for: cursor, in: children) {
+                let index = nextIndex(after: currentIndex, count: children.count, direction: direction)
+                return Selection(action: children[index], index: index, key: key)
+            }
+
+            // The selected child was removed, so re-seed from the updated cycle
+            cursors[key] = nil
+        }
+
+        if let seedAction,
+           let seedIndex = children.firstIndex(where: { $0.id == seedAction.id }) {
+            let index = nextIndex(after: seedIndex, count: children.count, direction: direction)
+            return Selection(action: children[index], index: index, key: key)
+        }
+
+        return Selection(action: children[0], index: 0, key: key)
+    }
+
+    /// Records a selection only if it still matches the current cycle
+    @discardableResult
+    mutating func accept(
+        _ selection: Selection,
+        for targetWindowID: CGWindowID,
+        in cycleAction: WindowAction
+    ) -> Bool {
+        let key = Key(
+            targetWindowID: targetWindowID,
+            parentCycleActionID: cycleAction.id
+        )
+
+        guard key == selection.key else {
+            return false
+        }
+
+        guard cycleAction.direction == .cycle,
+              let children = cycleAction.cycle,
+              !children.isEmpty
+        else {
+            cursors[key] = nil
+            return false
+        }
+
+        let acceptedIndex: Int? = if children.indices.contains(selection.index),
+                                     children[selection.index].id == selection.action.id {
+            selection.index
+        } else {
+            children.firstIndex(where: { $0.id == selection.action.id })
+        }
+
+        guard let acceptedIndex else {
+            cursors[key] = nil
+            return false
+        }
+
+        cursors[key] = Cursor(
+            childActionID: selection.action.id,
+            lastKnownIndex: acceptedIndex
+        )
+        return true
+    }
+
+    mutating func reset(for targetWindowID: CGWindowID) {
+        cursors = cursors.filter { $0.key.targetWindowID != targetWindowID }
+    }
+
+    mutating func reset() {
+        cursors.removeAll()
+    }
+
+    private func validatedIndex(for cursor: Cursor, in children: [WindowAction]) -> Int? {
+        if children.indices.contains(cursor.lastKnownIndex),
+           children[cursor.lastKnownIndex].id == cursor.childActionID {
+            return cursor.lastKnownIndex
+        }
+
+        return children.firstIndex(where: { $0.id == cursor.childActionID })
+    }
+
+    private func nextIndex(after index: Int, count: Int, direction: Direction) -> Int {
+        switch direction {
+        case .forward:
+            (index + 1) % count
+        case .backward:
+            index == 0 ? count - 1 : index - 1
+        }
+    }
+}

--- a/Loop/Window Management/Window Action/CycleProgressStore.swift
+++ b/Loop/Window Management/Window Action/CycleProgressStore.swift
@@ -41,6 +41,17 @@ struct CycleProgressStore {
 
     private var cursors: [Key: Cursor] = [:]
 
+    static func shouldRestartAtBeginning(
+        whenEnabled isEnabled: Bool,
+        currentAction: WindowAction,
+        in children: [WindowAction]
+    ) -> Bool {
+        isEnabled && (
+            currentAction.direction == .noSelection ||
+                !children.contains { $0.id == currentAction.id }
+        )
+    }
+
     /// Returns the next child without updating progress.
     ///
     /// Restarts at the first child when requested. Otherwise, uses stored progress before `seedAction`.

--- a/Loop/Window Management/Window Action/CycleProgressStore.swift
+++ b/Loop/Window Management/Window Action/CycleProgressStore.swift
@@ -130,6 +130,39 @@ struct CycleProgressStore {
         return acceptedAction
     }
 
+    mutating func proposeCurrentSelection(
+        for targetWindowID: CGWindowID,
+        in cycleAction: WindowAction,
+        seededBy seedAction: WindowAction?
+    ) -> Selection? {
+        let key = Key(
+            targetWindowID: targetWindowID,
+            parentCycleActionID: cycleAction.id
+        )
+
+        guard cycleAction.direction == .cycle,
+              let children = cycleAction.cycle,
+              !children.isEmpty
+        else {
+            cursors[key] = nil
+            return nil
+        }
+
+        if let seedAction,
+           let cursor = cursors[key],
+           cursor.childActionID == seedAction.id,
+           let index = validatedIndex(for: cursor, in: children) {
+            return Selection(action: children[index], index: index, key: key)
+        }
+
+        if let seedAction,
+           let index = children.firstIndex(where: { $0.id == seedAction.id }) {
+            return Selection(action: children[index], index: index, key: key)
+        }
+
+        return Selection(action: children[0], index: 0, key: key)
+    }
+
     private func validatedIndex(for cursor: Cursor, in children: [WindowAction]) -> Int? {
         if children.indices.contains(cursor.lastKnownIndex),
            children[cursor.lastKnownIndex].id == cursor.childActionID {

--- a/Loop/Window Management/Window Action/CycleProgressStore.swift
+++ b/Loop/Window Management/Window Action/CycleProgressStore.swift
@@ -41,26 +41,6 @@ struct CycleProgressStore {
 
     private var cursors: [Key: Cursor] = [:]
 
-    static func shouldRestartAtBeginning(
-        whenEnabled isEnabled: Bool,
-        currentAction: WindowAction,
-        currentParentAction: WindowAction?,
-        keybindSequenceOriginAction: WindowAction?,
-        in cycleAction: WindowAction
-    ) -> Bool {
-        let currentKeybind = currentParentAction?.keybind ?? currentAction.keybind
-        let isRepeatingLongerKeybind = keybindSequenceOriginAction?.id == cycleAction.id
-            && !currentKeybind.isEmpty
-            && currentKeybind.isStrictSubset(of: cycleAction.keybind)
-
-        return isEnabled && (
-            !isRepeatingLongerKeybind && (
-                currentAction.direction == .noSelection ||
-                    cycleAction.cycle?.contains { $0.id == currentAction.id } != true
-            )
-        )
-    }
-
     /// Returns the next child without updating progress.
     ///
     /// Restarts at the first child when requested. Otherwise, uses stored progress before `seedAction`.
@@ -107,20 +87,19 @@ struct CycleProgressStore {
         return Selection(action: children[0], index: 0, key: key)
     }
 
-    /// Records a selection only if it still matches the current cycle
-    @discardableResult
-    mutating func accept(
+    /// Records and returns a selection only if it still matches the current cycle
+    mutating func commit(
         _ selection: Selection,
         for targetWindowID: CGWindowID,
         in cycleAction: WindowAction
-    ) -> Bool {
+    ) -> WindowAction? {
         let key = Key(
             targetWindowID: targetWindowID,
             parentCycleActionID: cycleAction.id
         )
 
         guard key == selection.key else {
-            return false
+            return nil
         }
 
         guard cycleAction.direction == .cycle,
@@ -128,7 +107,7 @@ struct CycleProgressStore {
               !children.isEmpty
         else {
             cursors[key] = nil
-            return false
+            return nil
         }
 
         let acceptedIndex: Int? = if children.indices.contains(selection.index),
@@ -140,14 +119,15 @@ struct CycleProgressStore {
 
         guard let acceptedIndex else {
             cursors[key] = nil
-            return false
+            return nil
         }
 
+        let acceptedAction = children[acceptedIndex]
         cursors[key] = Cursor(
-            childActionID: selection.action.id,
+            childActionID: acceptedAction.id,
             lastKnownIndex: acceptedIndex
         )
-        return true
+        return acceptedAction
     }
 
     mutating func reset(for targetWindowID: CGWindowID) {

--- a/Loop/Window Management/Window Action/CycleProgressStore.swift
+++ b/Loop/Window Management/Window Action/CycleProgressStore.swift
@@ -44,11 +44,20 @@ struct CycleProgressStore {
     static func shouldRestartAtBeginning(
         whenEnabled isEnabled: Bool,
         currentAction: WindowAction,
-        in children: [WindowAction]
+        currentParentAction: WindowAction?,
+        keybindSequenceOriginAction: WindowAction?,
+        in cycleAction: WindowAction
     ) -> Bool {
-        isEnabled && (
-            currentAction.direction == .noSelection ||
-                !children.contains { $0.id == currentAction.id }
+        let currentKeybind = currentParentAction?.keybind ?? currentAction.keybind
+        let isRepeatingLongerKeybind = keybindSequenceOriginAction?.id == cycleAction.id
+            && !currentKeybind.isEmpty
+            && currentKeybind.isStrictSubset(of: cycleAction.keybind)
+
+        return isEnabled && (
+            !isRepeatingLongerKeybind && (
+                currentAction.direction == .noSelection ||
+                    cycleAction.cycle?.contains { $0.id == currentAction.id } != true
+            )
         )
     }
 

--- a/Loop/Window Management/Window Action/CycleProgressStore.swift
+++ b/Loop/Window Management/Window Action/CycleProgressStore.swift
@@ -130,14 +130,6 @@ struct CycleProgressStore {
         return acceptedAction
     }
 
-    mutating func reset(for targetWindowID: CGWindowID) {
-        cursors = cursors.filter { $0.key.targetWindowID != targetWindowID }
-    }
-
-    mutating func reset() {
-        cursors.removeAll()
-    }
-
     private func validatedIndex(for cursor: Cursor, in children: [WindowAction]) -> Int? {
         if children.indices.contains(cursor.lastKnownIndex),
            children[cursor.lastKnownIndex].id == cursor.childActionID {

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -82,6 +82,7 @@ final class ResizeContext {
     }
 
     /// Resolves the state needed before switching target windows
+    @concurrent
     static func prepareWindowTarget(_ window: Window?) async -> PreparedWindowTarget {
         let resolvedWindowProperties = window.map(Window.ResolvedProperties.init(from:))
         let resolvedRecord: WindowRecords.ResolvedRecord? = if let window {
@@ -114,7 +115,7 @@ final class ResizeContext {
     func proposeCycleAction(
         in cycleAction: WindowAction,
         restartAtBeginningWhenInterrupted: Bool,
-        direction: CycleProgressStore.Direction
+        mode: CycleActionCoordinator.SelectionMode
     ) -> CycleActionCoordinator.Proposal? {
         cycleActionCoordinator.proposeAction(
             for: window?.cgWindowID ?? 0,
@@ -123,7 +124,7 @@ final class ResizeContext {
             currentParentAction: parentAction,
             recordedAction: resolvedRecord?.currentAction,
             restartAtBeginningWhenInterrupted: restartAtBeginningWhenInterrupted,
-            direction: direction
+            mode: mode
         )
     }
 

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -101,20 +101,12 @@ final class ResizeContext {
     func commitWindowTarget(_ target: PreparedWindowTarget) {
         let window = target.window
 
-        let previousTargetWindowID = self.window?.cgWindowID
-        let nextTargetWindowID = window?.cgWindowID
-
         self.window = window
         resolvedWindowProperties = target.resolvedWindowProperties
         resolvedRecord = target.resolvedRecord
         lastAppliedFrame = nil
 
         needsRecompute = true
-
-        if previousTargetWindowID != nextTargetWindowID {
-            // CGWindowID 0 is reserved for the nil target
-            cycleActionCoordinator.resetProgress(for: previousTargetWindowID ?? 0)
-        }
 
         log.info("Set window to \(window?.description ?? "nil")")
     }
@@ -144,10 +136,6 @@ final class ResizeContext {
             for: window?.cgWindowID ?? 0,
             in: cycleAction
         )
-    }
-
-    func resetCycleProgress() {
-        cycleActionCoordinator.resetProgress()
     }
 
     func setAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -138,7 +138,10 @@ final class ResizeContext {
         )
     }
 
-    func setAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {
+    func setAction(
+        to newAction: WindowAction,
+        parent newParentAction: WindowAction?
+    ) {
         cycleActionCoordinator.recordActionTransition(
             from: action,
             currentParentAction: parentAction,

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -15,6 +15,12 @@ import SwiftUI
 /// along with the window, screen, and bounds information needed to compute frames.
 @Loggable
 final class ResizeContext {
+    struct PreparedWindowTarget {
+        fileprivate let window: Window?
+        fileprivate let resolvedWindowProperties: Window.ResolvedProperties?
+        fileprivate let resolvedRecord: WindowRecords.ResolvedRecord?
+    }
+
     private(set) var window: Window?
 
     private(set) var screen: NSScreen?
@@ -37,6 +43,7 @@ final class ResizeContext {
 
     private(set) var cachedTargetFrame: ComputedFrame = .zero
     private var needsRecompute: Bool = false
+    private var cycleProgressStore = CycleProgressStore()
     var lastAppliedFrame: CGRect?
 
     init(
@@ -74,15 +81,73 @@ final class ResizeContext {
         needsRecompute = true
     }
 
-    func setWindow(to window: Window?) {
+    /// Resolves the state needed before switching target windows
+    static func prepareWindowTarget(_ window: Window?) async -> PreparedWindowTarget {
+        let resolvedWindowProperties = window.map(Window.ResolvedProperties.init(from:))
+        let resolvedRecord: WindowRecords.ResolvedRecord? = if let window {
+            await WindowRecords.ResolvedRecord(for: window)
+        } else {
+            nil
+        }
+
+        return PreparedWindowTarget(
+            window: window,
+            resolvedWindowProperties: resolvedWindowProperties,
+            resolvedRecord: resolvedRecord
+        )
+    }
+
+    /// Switches to a prepared target window and its resolved state
+    func commitWindowTarget(_ target: PreparedWindowTarget) {
+        let window = target.window
+
+        let previousTargetWindowID = self.window?.cgWindowID
+        let nextTargetWindowID = window?.cgWindowID
+
         self.window = window
-        resolvedWindowProperties = nil
-        resolvedRecord = nil
+        resolvedWindowProperties = target.resolvedWindowProperties
+        resolvedRecord = target.resolvedRecord
         lastAppliedFrame = nil
 
         needsRecompute = true
 
+        if previousTargetWindowID != nextTargetWindowID {
+            // CGWindowID 0 is reserved for the nil target
+            cycleProgressStore.reset(for: previousTargetWindowID ?? 0)
+        }
+
         log.info("Set window to \(window?.description ?? "nil")")
+    }
+
+    func proposeCycleSelection(
+        in cycleAction: WindowAction,
+        seededBy seedAction: WindowAction?,
+        restartAtBeginning: Bool,
+        direction: CycleProgressStore.Direction
+    ) -> CycleProgressStore.Selection? {
+        cycleProgressStore.proposeSelection(
+            for: window?.cgWindowID ?? 0,
+            in: cycleAction,
+            seededBy: seedAction,
+            restartAtBeginning: restartAtBeginning,
+            direction: direction
+        )
+    }
+
+    @discardableResult
+    func acceptCycleSelection(
+        _ selection: CycleProgressStore.Selection,
+        in cycleAction: WindowAction
+    ) -> Bool {
+        cycleProgressStore.accept(
+            selection,
+            for: window?.cgWindowID ?? 0,
+            in: cycleAction
+        )
+    }
+
+    func resetCycleProgress() {
+        cycleProgressStore.reset()
     }
 
     func setAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -31,6 +31,7 @@ final class ResizeContext {
 
     private(set) var action: WindowAction = .init(.noSelection)
     private(set) var parentAction: WindowAction?
+    private(set) var keybindSequenceOriginAction: WindowAction?
 
     /// Used for larger/smaller actions where the sides to adjust need to persist across frame calculations
     var sidesToAdjust: Edge.Set?
@@ -151,6 +152,15 @@ final class ResizeContext {
     }
 
     func setAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {
+        let currentBindingAction = parentAction ?? action
+        let nextBindingAction = newParentAction ?? newAction
+        let continuesKeybindSequence = !currentBindingAction.keybind.isEmpty
+            && currentBindingAction.keybind.isStrictSubset(of: nextBindingAction.keybind)
+
+        if !continuesKeybindSequence {
+            keybindSequenceOriginAction = currentBindingAction
+        }
+
         action = newAction
         parentAction = newParentAction
         needsRecompute = true

--- a/Loop/Window Management/Window Manipulation/ResizeContext.swift
+++ b/Loop/Window Management/Window Manipulation/ResizeContext.swift
@@ -31,7 +31,6 @@ final class ResizeContext {
 
     private(set) var action: WindowAction = .init(.noSelection)
     private(set) var parentAction: WindowAction?
-    private(set) var keybindSequenceOriginAction: WindowAction?
 
     /// Used for larger/smaller actions where the sides to adjust need to persist across frame calculations
     var sidesToAdjust: Edge.Set?
@@ -44,7 +43,7 @@ final class ResizeContext {
 
     private(set) var cachedTargetFrame: ComputedFrame = .zero
     private var needsRecompute: Bool = false
-    private var cycleProgressStore = CycleProgressStore()
+    private var cycleActionCoordinator = CycleActionCoordinator()
     var lastAppliedFrame: CGRect?
 
     init(
@@ -114,52 +113,50 @@ final class ResizeContext {
 
         if previousTargetWindowID != nextTargetWindowID {
             // CGWindowID 0 is reserved for the nil target
-            cycleProgressStore.reset(for: previousTargetWindowID ?? 0)
+            cycleActionCoordinator.resetProgress(for: previousTargetWindowID ?? 0)
         }
 
         log.info("Set window to \(window?.description ?? "nil")")
     }
 
-    func proposeCycleSelection(
+    func proposeCycleAction(
         in cycleAction: WindowAction,
-        seededBy seedAction: WindowAction?,
-        restartAtBeginning: Bool,
+        restartAtBeginningWhenInterrupted: Bool,
         direction: CycleProgressStore.Direction
-    ) -> CycleProgressStore.Selection? {
-        cycleProgressStore.proposeSelection(
+    ) -> CycleActionCoordinator.Proposal? {
+        cycleActionCoordinator.proposeAction(
             for: window?.cgWindowID ?? 0,
             in: cycleAction,
-            seededBy: seedAction,
-            restartAtBeginning: restartAtBeginning,
+            currentAction: action,
+            currentParentAction: parentAction,
+            recordedAction: resolvedRecord?.currentAction,
+            restartAtBeginningWhenInterrupted: restartAtBeginningWhenInterrupted,
             direction: direction
         )
     }
 
-    @discardableResult
-    func acceptCycleSelection(
-        _ selection: CycleProgressStore.Selection,
+    func commitCycleAction(
+        _ proposal: CycleActionCoordinator.Proposal,
         in cycleAction: WindowAction
-    ) -> Bool {
-        cycleProgressStore.accept(
-            selection,
+    ) -> WindowAction? {
+        cycleActionCoordinator.commit(
+            proposal,
             for: window?.cgWindowID ?? 0,
             in: cycleAction
         )
     }
 
     func resetCycleProgress() {
-        cycleProgressStore.reset()
+        cycleActionCoordinator.resetProgress()
     }
 
     func setAction(to newAction: WindowAction, parent newParentAction: WindowAction?) {
-        let currentBindingAction = parentAction ?? action
-        let nextBindingAction = newParentAction ?? newAction
-        let continuesKeybindSequence = !currentBindingAction.keybind.isEmpty
-            && currentBindingAction.keybind.isStrictSubset(of: nextBindingAction.keybind)
-
-        if !continuesKeybindSequence {
-            keybindSequenceOriginAction = currentBindingAction
-        }
+        cycleActionCoordinator.recordActionTransition(
+            from: action,
+            currentParentAction: parentAction,
+            to: newAction,
+            newParentAction: newParentAction
+        )
 
         action = newAction
         parentAction = newParentAction

--- a/Loop/Window Management/Window Manipulation/WindowActionEngine.swift
+++ b/Loop/Window Management/Window Manipulation/WindowActionEngine.swift
@@ -128,14 +128,24 @@ final class WindowActionEngine {
 
     // MARK: - Focus Actions
 
-    private func handleFocusAction(_ action: WindowAction, currentWindow: Window?) -> Result {
-        let direction = action.direction
-        var newTargetWindow: Window?
+    func resolveFocusTarget(_ action: WindowAction, currentWindow: Window?) -> Window? {
+        if action.direction == .focusNextInStack {
+            WindowUtility.nextStackedWindow(from: currentWindow)
+        } else if let focusDirection = action.direction.focusDirection {
+            WindowUtility.directionalWindow(from: currentWindow, direction: focusDirection)
+        } else {
+            nil
+        }
+    }
 
-        if direction == .focusNextInStack {
-            newTargetWindow = WindowUtility.focusNextWindowInStack(from: currentWindow)
-        } else if let focusDirection = direction.focusDirection {
-            newTargetWindow = WindowUtility.focusWindow(from: currentWindow, direction: focusDirection)
+    private func handleFocusAction(_ action: WindowAction, currentWindow: Window?) -> Result {
+        let newTargetWindow = resolveFocusTarget(action, currentWindow: currentWindow)
+
+        if let newTargetWindow {
+            Task { @MainActor in
+                log.info("Focusing window: \(newTargetWindow.description)")
+                newTargetWindow.focus()
+            }
         }
 
         return .focused(newTargetWindow)

--- a/Loop/Window Management/Window Manipulation/WindowActionEngine.swift
+++ b/Loop/Window Management/Window Manipulation/WindowActionEngine.swift
@@ -108,7 +108,7 @@ final class WindowActionEngine {
 
         // Focus actions: find and focus the target window
         if direction.willFocusWindow {
-            return handleFocusAction(context.action, currentWindow: context.window)
+            return await handleFocusAction(context.action, currentWindow: context.window)
         }
 
         // Cross-space throws
@@ -128,7 +128,8 @@ final class WindowActionEngine {
 
     // MARK: - Focus Actions
 
-    func resolveFocusTarget(_ action: WindowAction, currentWindow: Window?) -> Window? {
+    @concurrent
+    func resolveFocusTarget(_ action: WindowAction, currentWindow: Window?) async -> Window? {
         if action.direction == .focusNextInStack {
             WindowUtility.nextStackedWindow(from: currentWindow)
         } else if let focusDirection = action.direction.focusDirection {
@@ -138,8 +139,8 @@ final class WindowActionEngine {
         }
     }
 
-    private func handleFocusAction(_ action: WindowAction, currentWindow: Window?) -> Result {
-        let newTargetWindow = resolveFocusTarget(action, currentWindow: currentWindow)
+    private func handleFocusAction(_ action: WindowAction, currentWindow: Window?) async -> Result {
+        let newTargetWindow = await resolveFocusTarget(action, currentWindow: currentWindow)
 
         if let newTargetWindow {
             Task { @MainActor in

--- a/Loop/Window Management/Window Manipulation/WindowRecords.swift
+++ b/Loop/Window Management/Window Manipulation/WindowRecords.swift
@@ -28,10 +28,12 @@ actor WindowRecords {
     struct ResolvedRecord {
         let initialFrame: CGRect?
         let lastAction: WindowAction?
+        let currentAction: WindowAction?
 
         init(for window: Window) async {
             self.initialFrame = await WindowRecords.shared.getInitialFrame(for: window)
             self.lastAction = await WindowRecords.shared.getLastAction(for: window)
+            self.currentAction = await WindowRecords.shared.getCurrentAction(for: window)
         }
     }
 

--- a/Loop/Window Management/Window/WindowUtility+FocusNavigation.swift
+++ b/Loop/Window Management/Window/WindowUtility+FocusNavigation.swift
@@ -16,50 +16,12 @@ extension WindowUtility {
         frameProvider: \.frame
     )
 
-    /// Focuses the next window in the specified direction.
-    /// - Parameters:
-    ///   - currentWindow: The currently focused window to navigate from, or nil to navigate from screen center
-    ///   - direction: The direction to search for the next window (focusUp, focusDown, focusLeft, focusRight)
-    static func focusWindow(from currentWindow: Window?, direction: NavigationDirection) -> Window? {
-        guard let directionalWindow = WindowUtility.directionalWindow(
-            from: currentWindow,
-            direction: direction
-        ) else {
-            log.info("No window found to focus in direction \(direction)")
-            return nil
-        }
-
-        let nextWindowTitle = directionalWindow.nsRunningApplication?.localizedName ?? directionalWindow.title ?? "<unknown>"
-        log.info("Focusing window: \(nextWindowTitle)")
-
-        Task { @MainActor in
-            directionalWindow.focus()
-        }
-
-        return directionalWindow
-    }
-
-    static func focusNextWindowInStack(from currentWindow: Window?) -> Window? {
-        guard let directionalWindow = WindowUtility.nextStackedWindow(from: currentWindow) else {
-            return nil
-        }
-
-        let nextWindowTitle = directionalWindow.nsRunningApplication?.localizedName ?? directionalWindow.title ?? "<unknown>"
-        log.info("Focusing window: \(nextWindowTitle)")
-
-        Task { @MainActor in
-            directionalWindow.focus()
-        }
-
-        return directionalWindow
-    }
-
     /// Finds the next window to focus in the specified direction.
     /// - Parameters:
     ///   - currentWindow: The currently focused window to navigate from, or nil to navigate from screen center
     ///   - edge: The direction to search for the next window (leading, trailing, top, bottom)
     /// - Returns: The next window in the specified direction, or `nil` if no suitable window is found
-    private static func directionalWindow(
+    static func directionalWindow(
         from currentWindow: Window?,
         direction: NavigationDirection
     ) -> Window? {
@@ -128,7 +90,7 @@ extension WindowUtility {
     /// - Parameters:
     ///   - currentWindow: The currently focused window to cycle from
     /// - Returns: The next window in the stack cycle, or `nil` if no suitable window is found
-    private static func nextStackedWindow(
+    static func nextStackedWindow(
         from currentWindow: Window?
     ) -> Window? {
         let allWindows = windowList()

--- a/LoopTests/CycleActionCoordinatorTests.swift
+++ b/LoopTests/CycleActionCoordinatorTests.swift
@@ -1,0 +1,75 @@
+//
+//  CycleActionCoordinatorTests.swift
+//  LoopTests
+//
+//  Created by Kai Azim on 2026-08-30.
+//
+
+@testable import Loop
+import Testing
+
+struct CycleActionCoordinatorTests {
+    @Test func restartPolicyOnlyRestartsInterruptedCyclesWhenEnabled() {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.rightHalf)
+        let outside = WindowAction(.maximize)
+        let children = [first, second]
+        let cycle = WindowAction(children)
+        let prefixCycle = WindowAction(cycle: [outside], keybind: [.kVK_LeftArrow])
+        let dualKeyCycle = WindowAction(
+            cycle: children,
+            keybind: [.kVK_LeftArrow, .kVK_RightArrow]
+        )
+        let unrelatedCycle = WindowAction(cycle: [outside], keybind: [.kVK_UpArrow])
+
+        #expect(CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: nil,
+            keybindSequenceOriginAction: nil,
+            in: cycle
+        ))
+        #expect(CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: .init(.noSelection),
+            currentParentAction: nil,
+            keybindSequenceOriginAction: nil,
+            in: cycle
+        ))
+        #expect(!CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: first,
+            currentParentAction: cycle,
+            keybindSequenceOriginAction: nil,
+            in: cycle
+        ))
+        #expect(!CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: false,
+            currentAction: outside,
+            currentParentAction: nil,
+            keybindSequenceOriginAction: nil,
+            in: cycle
+        ))
+        #expect(CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: prefixCycle,
+            keybindSequenceOriginAction: nil,
+            in: dualKeyCycle
+        ))
+        #expect(!CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: prefixCycle,
+            keybindSequenceOriginAction: dualKeyCycle,
+            in: dualKeyCycle
+        ))
+        #expect(CycleActionCoordinator.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: prefixCycle,
+            keybindSequenceOriginAction: unrelatedCycle,
+            in: dualKeyCycle
+        ))
+    }
+}

--- a/LoopTests/CycleActionCoordinatorTests.swift
+++ b/LoopTests/CycleActionCoordinatorTests.swift
@@ -5,10 +5,13 @@
 //  Created by Kai Azim on 2026-08-30.
 //
 
+import CoreGraphics
 @testable import Loop
 import Testing
 
 struct CycleActionCoordinatorTests {
+    private let targetWindowID: CGWindowID = 1
+
     @Test func restartPolicyOnlyRestartsInterruptedCyclesWhenEnabled() {
         let first = WindowAction(.leftHalf)
         let second = WindowAction(.rightHalf)
@@ -71,5 +74,86 @@ struct CycleActionCoordinatorTests {
             keybindSequenceOriginAction: unrelatedCycle,
             in: dualKeyCycle
         ))
+    }
+
+    @Test func selectingCurrentChildUpdatesStoredProgress() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.maximize)
+        let cycle = WindowAction([first, second])
+        let noSelection = WindowAction(.noSelection)
+        var coordinator = CycleActionCoordinator()
+
+        _ = try commitNext(
+            with: &coordinator,
+            in: cycle,
+            currentAction: noSelection,
+            currentParentAction: nil,
+            restartAtBeginning: true
+        )
+        let secondSelection = try commitNext(
+            with: &coordinator,
+            in: cycle,
+            currentAction: first,
+            currentParentAction: cycle
+        )
+        coordinator.recordActionTransition(
+            from: secondSelection,
+            currentParentAction: cycle,
+            to: noSelection,
+            newParentAction: nil
+        )
+        let radialSelection = try commitNext(
+            with: &coordinator,
+            in: cycle,
+            currentAction: noSelection,
+            currentParentAction: nil,
+            mode: .selectCurrent
+        )
+        coordinator.recordActionTransition(
+            from: noSelection,
+            currentParentAction: nil,
+            to: radialSelection,
+            newParentAction: cycle
+        )
+
+        let nextProposal = coordinator.proposeAction(
+            for: targetWindowID,
+            in: cycle,
+            currentAction: first,
+            currentParentAction: cycle,
+            recordedAction: nil,
+            restartAtBeginningWhenInterrupted: true,
+            mode: .advance(.forward)
+        )
+        let next = try #require(nextProposal)
+
+        #expect(radialSelection.id == first.id)
+        #expect(next.action.id == second.id)
+    }
+
+    private func commitNext(
+        with coordinator: inout CycleActionCoordinator,
+        in cycle: WindowAction,
+        currentAction: WindowAction,
+        currentParentAction: WindowAction?,
+        restartAtBeginning: Bool = false,
+        mode: CycleActionCoordinator.SelectionMode = .advance(.forward)
+    ) throws -> WindowAction {
+        let nextProposal = coordinator.proposeAction(
+            for: targetWindowID,
+            in: cycle,
+            currentAction: currentAction,
+            currentParentAction: currentParentAction,
+            recordedAction: nil,
+            restartAtBeginningWhenInterrupted: restartAtBeginning,
+            mode: mode
+        )
+        let proposal = try #require(nextProposal)
+        let committedAction = coordinator.commit(
+            proposal,
+            for: targetWindowID,
+            in: cycle
+        )
+        return try #require(committedAction)
     }
 }

--- a/LoopTests/CycleProgressStoreTests.swift
+++ b/LoopTests/CycleProgressStoreTests.swift
@@ -222,6 +222,34 @@ struct CycleProgressStoreTests {
         #expect([first.index, forward.index, backward.index] == [0, 0, 0])
     }
 
+    @Test func selectingDuplicateChildPreservesSelectedOccurrence() throws {
+        let repeated = WindowAction(.leftHalf)
+        let middle = WindowAction(.maximize)
+        let cycle = WindowAction([repeated, middle, repeated])
+        var store = CycleProgressStore()
+
+        _ = try commitNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        _ = try commitNext(in: &store, target: targetA, cycle: cycle)
+        _ = try commitNext(in: &store, target: targetA, cycle: cycle)
+        let currentSelection = store.proposeCurrentSelection(
+            for: targetA,
+            in: cycle,
+            seededBy: repeated
+        )
+        let selected = try #require(currentSelection)
+        _ = store.commit(selected, for: targetA, in: cycle)
+
+        let next = try selection(from: &store, target: targetA, cycle: cycle)
+
+        #expect(selected.index == 2)
+        #expect(next.index == 0)
+    }
+
     private func selection(
         from store: inout CycleProgressStore,
         target: CGWindowID,

--- a/LoopTests/CycleProgressStoreTests.swift
+++ b/LoopTests/CycleProgressStoreTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 struct CycleProgressStoreTests {
     private let targetA: CGWindowID = 1
+    private let targetB: CGWindowID = 2
 
     @Test func restartBeginsAtTheFirstChildEvenWithStoredProgress() throws {
         let first = WindowAction(.leftHalf)
@@ -169,7 +170,7 @@ struct CycleProgressStoreTests {
         #expect(selection.index == 0)
     }
 
-    @Test func targetChangeClearsThePreviousWindowsCursor() throws {
+    @Test func targetWindowsKeepIndependentCursors() throws {
         let first = WindowAction(.leftHalf)
         let second = WindowAction(.maximize)
         let third = WindowAction(.rightHalf)
@@ -182,41 +183,18 @@ struct CycleProgressStoreTests {
             cycle: cycle,
             restartAtBeginning: true
         )
-        store.reset(for: targetA)
-
-        let reseeded = try selection(
-            from: &store,
-            target: targetA,
-            cycle: cycle,
-            seededBy: second
-        )
-
-        #expect(reseeded.action.id == third.id)
-    }
-
-    @Test func shutdownClearsCycleProgress() throws {
-        let first = WindowAction(.leftHalf)
-        let second = WindowAction(.maximize)
-        let third = WindowAction(.rightHalf)
-        let cycle = WindowAction([first, second, third])
-        var store = CycleProgressStore()
-
+        _ = try commitNext(in: &store, target: targetA, cycle: cycle)
         _ = try commitNext(
             in: &store,
-            target: targetA,
+            target: targetB,
             cycle: cycle,
             restartAtBeginning: true
         )
-        store.reset()
+        let nextA = try selection(from: &store, target: targetA, cycle: cycle)
+        let nextB = try selection(from: &store, target: targetB, cycle: cycle)
 
-        let reseeded = try selection(
-            from: &store,
-            target: targetA,
-            cycle: cycle,
-            seededBy: second
-        )
-
-        #expect(reseeded.action.id == third.id)
+        #expect(nextA.action.id == third.id)
+        #expect(nextB.action.id == second.id)
     }
 
     @Test func singleChildCycleRemainsOnItsOnlyChild() throws {

--- a/LoopTests/CycleProgressStoreTests.swift
+++ b/LoopTests/CycleProgressStoreTests.swift
@@ -12,83 +12,19 @@ import Testing
 struct CycleProgressStoreTests {
     private let targetA: CGWindowID = 1
 
-    @Test func restartPolicyOnlyRestartsInterruptedCyclesWhenEnabled() {
-        let first = WindowAction(.leftHalf)
-        let second = WindowAction(.rightHalf)
-        let outside = WindowAction(.maximize)
-        let children = [first, second]
-        let cycle = WindowAction(children)
-        let prefixCycle = WindowAction(cycle: [outside], keybind: [.kVK_LeftArrow])
-        let dualKeyCycle = WindowAction(
-            cycle: children,
-            keybind: [.kVK_LeftArrow, .kVK_RightArrow]
-        )
-        let unrelatedCycle = WindowAction(cycle: [outside], keybind: [.kVK_UpArrow])
-
-        #expect(CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: true,
-            currentAction: outside,
-            currentParentAction: nil,
-            keybindSequenceOriginAction: nil,
-            in: cycle
-        ))
-        #expect(CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: true,
-            currentAction: .init(.noSelection),
-            currentParentAction: nil,
-            keybindSequenceOriginAction: nil,
-            in: cycle
-        ))
-        #expect(!CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: true,
-            currentAction: first,
-            currentParentAction: cycle,
-            keybindSequenceOriginAction: nil,
-            in: cycle
-        ))
-        #expect(!CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: false,
-            currentAction: outside,
-            currentParentAction: nil,
-            keybindSequenceOriginAction: nil,
-            in: cycle
-        ))
-        #expect(CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: true,
-            currentAction: outside,
-            currentParentAction: prefixCycle,
-            keybindSequenceOriginAction: nil,
-            in: dualKeyCycle
-        ))
-        #expect(!CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: true,
-            currentAction: outside,
-            currentParentAction: prefixCycle,
-            keybindSequenceOriginAction: dualKeyCycle,
-            in: dualKeyCycle
-        ))
-        #expect(CycleProgressStore.shouldRestartAtBeginning(
-            whenEnabled: true,
-            currentAction: outside,
-            currentParentAction: prefixCycle,
-            keybindSequenceOriginAction: unrelatedCycle,
-            in: dualKeyCycle
-        ))
-    }
-
     @Test func restartBeginsAtTheFirstChildEvenWithStoredProgress() throws {
         let first = WindowAction(.leftHalf)
         let second = WindowAction(.rightHalf)
         let cycle = WindowAction([first, second])
         var store = CycleProgressStore()
 
-        _ = try acceptNext(
+        _ = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
             restartAtBeginning: true
         )
-        let secondSelection = try acceptNext(
+        let secondSelection = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle
@@ -113,7 +49,7 @@ struct CycleProgressStoreTests {
         var store = CycleProgressStore()
 
         let selections = try (0 ..< 4).map { index in
-            try acceptNext(
+            try commitNext(
                 in: &store,
                 target: targetA,
                 cycle: cycle,
@@ -132,19 +68,19 @@ struct CycleProgressStoreTests {
         let cycle = WindowAction([first, second, third])
         var store = CycleProgressStore()
 
-        let initial = try acceptNext(
+        let initial = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
             restartAtBeginning: true
         )
-        let wrapped = try acceptNext(
+        let wrapped = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
             direction: .backward
         )
-        let previous = try acceptNext(
+        let previous = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
@@ -165,13 +101,13 @@ struct CycleProgressStoreTests {
         let cycleB = WindowAction([firstB, secondB])
         var store = CycleProgressStore()
 
-        _ = try acceptNext(
+        _ = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycleA,
             restartAtBeginning: true
         )
-        let seededB = try acceptNext(
+        let seededB = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycleB,
@@ -194,7 +130,7 @@ struct CycleProgressStoreTests {
         var cycle = WindowAction([first, second, third])
         var store = CycleProgressStore()
 
-        _ = try acceptNext(
+        _ = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
@@ -214,13 +150,13 @@ struct CycleProgressStoreTests {
         var cycle = WindowAction([first, removed, third])
         var store = CycleProgressStore()
 
-        _ = try acceptNext(
+        _ = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
             restartAtBeginning: true
         )
-        _ = try acceptNext(in: &store, target: targetA, cycle: cycle)
+        _ = try commitNext(in: &store, target: targetA, cycle: cycle)
         cycle.cycle = [first, third]
         let selection = try selection(
             from: &store,
@@ -240,7 +176,7 @@ struct CycleProgressStoreTests {
         let cycle = WindowAction([first, second, third])
         var store = CycleProgressStore()
 
-        _ = try acceptNext(
+        _ = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
@@ -265,7 +201,7 @@ struct CycleProgressStoreTests {
         let cycle = WindowAction([first, second, third])
         var store = CycleProgressStore()
 
-        _ = try acceptNext(
+        _ = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
@@ -288,13 +224,13 @@ struct CycleProgressStoreTests {
         let cycle = WindowAction([only])
         var store = CycleProgressStore()
 
-        let first = try acceptNext(
+        let first = try commitNext(
             in: &store,
             target: targetA,
             cycle: cycle,
             restartAtBeginning: true
         )
-        let forward = try acceptNext(in: &store, target: targetA, cycle: cycle)
+        let forward = try commitNext(in: &store, target: targetA, cycle: cycle)
         let backward = try selection(
             from: &store,
             target: targetA,
@@ -326,7 +262,7 @@ struct CycleProgressStoreTests {
         return try #require(selection)
     }
 
-    private func acceptNext(
+    private func commitNext(
         in store: inout CycleProgressStore,
         target: CGWindowID,
         cycle: WindowAction,
@@ -342,8 +278,8 @@ struct CycleProgressStoreTests {
             restartAtBeginning: restartAtBeginning,
             direction: direction
         )
-        let accepted = store.accept(selection, for: target, in: cycle)
-        #expect(accepted)
+        let committedAction = store.commit(selection, for: target, in: cycle)
+        #expect(committedAction?.id == selection.action.id)
         return selection
     }
 }

--- a/LoopTests/CycleProgressStoreTests.swift
+++ b/LoopTests/CycleProgressStoreTests.swift
@@ -1,0 +1,313 @@
+//
+//  CycleProgressStoreTests.swift
+//  LoopTests
+//
+//  Created by Kai Azim on 2026-08-29.
+//
+
+import CoreGraphics
+@testable import Loop
+import Testing
+
+struct CycleProgressStoreTests {
+    private let targetA: CGWindowID = 1
+
+    @Test func restartPolicyOnlyRestartsInterruptedCyclesWhenEnabled() {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.rightHalf)
+        let outside = WindowAction(.maximize)
+        let children = [first, second]
+
+        #expect(CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            in: children
+        ))
+        #expect(CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: .init(.noSelection),
+            in: children
+        ))
+        #expect(!CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: first,
+            in: children
+        ))
+        #expect(!CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: false,
+            currentAction: outside,
+            in: children
+        ))
+    }
+
+    @Test func restartBeginsAtTheFirstChildEvenWithStoredProgress() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.rightHalf)
+        let cycle = WindowAction([first, second])
+        var store = CycleProgressStore()
+
+        _ = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        let secondSelection = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle
+        )
+        let restarted = try selection(
+            from: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+
+        #expect(secondSelection.action.id == second.id)
+        #expect(restarted.action.id == first.id)
+        #expect(restarted.index == 0)
+    }
+
+    @Test func storedProgressAdvancesAndWrapsForward() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.maximize)
+        let third = WindowAction(.rightHalf)
+        let cycle = WindowAction([first, second, third])
+        var store = CycleProgressStore()
+
+        let selections = try (0 ..< 4).map { index in
+            try acceptNext(
+                in: &store,
+                target: targetA,
+                cycle: cycle,
+                restartAtBeginning: index == 0
+            )
+        }
+
+        #expect(selections.map(\.action.id) == [first.id, second.id, third.id, first.id])
+        #expect(selections.map(\.index) == [0, 1, 2, 0])
+    }
+
+    @Test func storedProgressAdvancesAndWrapsBackward() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.maximize)
+        let third = WindowAction(.rightHalf)
+        let cycle = WindowAction([first, second, third])
+        var store = CycleProgressStore()
+
+        let initial = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        let wrapped = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            direction: .backward
+        )
+        let previous = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            direction: .backward
+        )
+
+        #expect(initial.action.id == first.id)
+        #expect(wrapped.action.id == third.id)
+        #expect(previous.action.id == second.id)
+    }
+
+    @Test func parentCyclesKeepIndependentCursors() throws {
+        let firstA = WindowAction(.leftHalf)
+        let secondA = WindowAction(.rightHalf)
+        let firstB = WindowAction(.topHalf)
+        let secondB = WindowAction(.bottomHalf)
+        let cycleA = WindowAction([firstA, secondA])
+        let cycleB = WindowAction([firstB, secondB])
+        var store = CycleProgressStore()
+
+        _ = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycleA,
+            restartAtBeginning: true
+        )
+        let seededB = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycleB,
+            restartAtBeginning: true
+        )
+        let resumedA = try selection(
+            from: &store,
+            target: targetA,
+            cycle: cycleA
+        )
+
+        #expect(seededB.action.id == firstB.id)
+        #expect(resumedA.action.id == secondA.id)
+    }
+
+    @Test func reorderedChildrenFollowTheSelectedChildID() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.maximize)
+        let third = WindowAction(.rightHalf)
+        var cycle = WindowAction([first, second, third])
+        var store = CycleProgressStore()
+
+        _ = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        cycle.cycle = [second, first, third]
+        let selection = try selection(from: &store, target: targetA, cycle: cycle)
+
+        #expect(selection.action.id == third.id)
+        #expect(selection.index == 2)
+    }
+
+    @Test func removedSelectedChildReseedsFromTheUpdatedCycle() throws {
+        let first = WindowAction(.leftHalf)
+        let removed = WindowAction(.maximize)
+        let third = WindowAction(.rightHalf)
+        var cycle = WindowAction([first, removed, third])
+        var store = CycleProgressStore()
+
+        _ = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        _ = try acceptNext(in: &store, target: targetA, cycle: cycle)
+        cycle.cycle = [first, third]
+        let selection = try selection(
+            from: &store,
+            target: targetA,
+            cycle: cycle,
+            seededBy: third
+        )
+
+        #expect(selection.action.id == first.id)
+        #expect(selection.index == 0)
+    }
+
+    @Test func targetChangeClearsThePreviousWindowsCursor() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.maximize)
+        let third = WindowAction(.rightHalf)
+        let cycle = WindowAction([first, second, third])
+        var store = CycleProgressStore()
+
+        _ = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        store.reset(for: targetA)
+
+        let reseeded = try selection(
+            from: &store,
+            target: targetA,
+            cycle: cycle,
+            seededBy: second
+        )
+
+        #expect(reseeded.action.id == third.id)
+    }
+
+    @Test func shutdownClearsCycleProgress() throws {
+        let first = WindowAction(.leftHalf)
+        let second = WindowAction(.maximize)
+        let third = WindowAction(.rightHalf)
+        let cycle = WindowAction([first, second, third])
+        var store = CycleProgressStore()
+
+        _ = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        store.reset()
+
+        let reseeded = try selection(
+            from: &store,
+            target: targetA,
+            cycle: cycle,
+            seededBy: second
+        )
+
+        #expect(reseeded.action.id == third.id)
+    }
+
+    @Test func singleChildCycleRemainsOnItsOnlyChild() throws {
+        let only = WindowAction(.leftHalf)
+        let cycle = WindowAction([only])
+        var store = CycleProgressStore()
+
+        let first = try acceptNext(
+            in: &store,
+            target: targetA,
+            cycle: cycle,
+            restartAtBeginning: true
+        )
+        let forward = try acceptNext(in: &store, target: targetA, cycle: cycle)
+        let backward = try selection(
+            from: &store,
+            target: targetA,
+            cycle: cycle,
+            direction: .backward
+        )
+
+        #expect(first.action.id == only.id)
+        #expect(forward.action.id == only.id)
+        #expect(backward.action.id == only.id)
+        #expect([first.index, forward.index, backward.index] == [0, 0, 0])
+    }
+
+    private func selection(
+        from store: inout CycleProgressStore,
+        target: CGWindowID,
+        cycle: WindowAction,
+        seededBy seedAction: WindowAction? = nil,
+        restartAtBeginning: Bool = false,
+        direction: CycleProgressStore.Direction = .forward
+    ) throws -> CycleProgressStore.Selection {
+        let selection = store.proposeSelection(
+            for: target,
+            in: cycle,
+            seededBy: seedAction,
+            restartAtBeginning: restartAtBeginning,
+            direction: direction
+        )
+        return try #require(selection)
+    }
+
+    private func acceptNext(
+        in store: inout CycleProgressStore,
+        target: CGWindowID,
+        cycle: WindowAction,
+        seededBy seedAction: WindowAction? = nil,
+        restartAtBeginning: Bool = false,
+        direction: CycleProgressStore.Direction = .forward
+    ) throws -> CycleProgressStore.Selection {
+        let selection = try selection(
+            from: &store,
+            target: target,
+            cycle: cycle,
+            seededBy: seedAction,
+            restartAtBeginning: restartAtBeginning,
+            direction: direction
+        )
+        let accepted = store.accept(selection, for: target, in: cycle)
+        #expect(accepted)
+        return selection
+    }
+}

--- a/LoopTests/CycleProgressStoreTests.swift
+++ b/LoopTests/CycleProgressStoreTests.swift
@@ -17,26 +17,62 @@ struct CycleProgressStoreTests {
         let second = WindowAction(.rightHalf)
         let outside = WindowAction(.maximize)
         let children = [first, second]
+        let cycle = WindowAction(children)
+        let prefixCycle = WindowAction(cycle: [outside], keybind: [.kVK_LeftArrow])
+        let dualKeyCycle = WindowAction(
+            cycle: children,
+            keybind: [.kVK_LeftArrow, .kVK_RightArrow]
+        )
+        let unrelatedCycle = WindowAction(cycle: [outside], keybind: [.kVK_UpArrow])
 
         #expect(CycleProgressStore.shouldRestartAtBeginning(
             whenEnabled: true,
             currentAction: outside,
-            in: children
+            currentParentAction: nil,
+            keybindSequenceOriginAction: nil,
+            in: cycle
         ))
         #expect(CycleProgressStore.shouldRestartAtBeginning(
             whenEnabled: true,
             currentAction: .init(.noSelection),
-            in: children
+            currentParentAction: nil,
+            keybindSequenceOriginAction: nil,
+            in: cycle
         ))
         #expect(!CycleProgressStore.shouldRestartAtBeginning(
             whenEnabled: true,
             currentAction: first,
-            in: children
+            currentParentAction: cycle,
+            keybindSequenceOriginAction: nil,
+            in: cycle
         ))
         #expect(!CycleProgressStore.shouldRestartAtBeginning(
             whenEnabled: false,
             currentAction: outside,
-            in: children
+            currentParentAction: nil,
+            keybindSequenceOriginAction: nil,
+            in: cycle
+        ))
+        #expect(CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: prefixCycle,
+            keybindSequenceOriginAction: nil,
+            in: dualKeyCycle
+        ))
+        #expect(!CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: prefixCycle,
+            keybindSequenceOriginAction: dualKeyCycle,
+            in: dualKeyCycle
+        ))
+        #expect(CycleProgressStore.shouldRestartAtBeginning(
+            whenEnabled: true,
+            currentAction: outside,
+            currentParentAction: prefixCycle,
+            keybindSequenceOriginAction: unrelatedCycle,
+            in: dualKeyCycle
         ))
     }
 

--- a/LoopTests/KeybindResolverTests.swift
+++ b/LoopTests/KeybindResolverTests.swift
@@ -49,33 +49,14 @@ struct KeybindResolverTests {
             actions: actions
         )
 
-        try expectAction(
-            singleDown,
-            action: singleCycle,
-            source: .trigger,
-            category: .cycle,
-            activation: .activate
-        )
-        try expectAction(
-            chordDown,
-            action: chordCycle,
-            source: .trigger,
-            category: .cycle,
-            activation: .activate
-        )
-        #expect(chordKeyUp.match == .none)
+        try expectOpen(singleDown.effect, action: singleCycle, overridesDelayAction: true)
+        try expectOpen(chordDown.effect, action: chordCycle, overridesDelayAction: true)
         #expect(chordKeyUp.effect == .none)
         #expect(chordKeyUp.handling == .forward)
-        try expectAction(
-            chordRepressed,
-            action: chordCycle,
-            source: .trigger,
-            category: .cycle,
-            activation: .activate
-        )
+        try expectOpen(chordRepressed.effect, action: chordCycle, overridesDelayAction: true)
     }
 
-    @Test func cycleAutorepeatIsSuppressed() throws {
+    @Test func cycleAutorepeatIsSuppressed() {
         let cycle = WindowAction([
             .init(.leftHalf),
             .init(.rightHalf)
@@ -87,18 +68,11 @@ struct KeybindResolverTests {
             actions: [[keyA]: cycle]
         )
 
-        try expectAction(
-            decision,
-            action: cycle,
-            source: .trigger,
-            category: .cycle,
-            activation: .suppressAutorepeat
-        )
         #expect(decision.effect == .none)
         #expect(decision.handling == .consumeIfLoopOpenOtherwiseOpening)
     }
 
-    @Test func nonRepeatableActionAutorepeatIsSuppressed() throws {
+    @Test func nonRepeatableActionAutorepeatIsSuppressed() {
         let action = WindowAction(.leftHalf)
         let decision = resolve(
             eventType: .keyDown,
@@ -107,14 +81,8 @@ struct KeybindResolverTests {
             actions: [[keyA]: action]
         )
 
-        try expectAction(
-            decision,
-            action: action,
-            source: .trigger,
-            category: .nonRepeatable,
-            activation: .suppressAutorepeat
-        )
         #expect(decision.effect == .none)
+        #expect(decision.handling == .consumeIfLoopOpenOtherwiseOpening)
     }
 
     @Test func repeatableActionActivatesOnAutorepeat() throws {
@@ -126,14 +94,8 @@ struct KeybindResolverTests {
             actions: [[keyA]: action]
         )
 
-        try expectAction(
-            decision,
-            action: action,
-            source: .trigger,
-            category: .repeatableNonCycle,
-            activation: .activate
-        )
         try expectOpen(decision.effect, action: action, overridesDelayAction: true)
+        #expect(decision.handling == .consumeIfLoopOpenOtherwiseOpening)
     }
 
     @Test func bypassActionActivatesWithoutTheTriggerKey() throws {
@@ -146,14 +108,8 @@ struct KeybindResolverTests {
             bypassedActions: [[keyA]: action]
         )
 
-        try expectAction(
-            decision,
-            action: action,
-            source: .bypassTrigger,
-            category: .nonRepeatable,
-            activation: .activate
-        )
         try expectOpen(decision.effect, action: action, overridesDelayAction: true)
+        #expect(decision.handling == .consumeIfLoopOpenOtherwiseOpening)
     }
 
     @Test func sideIndependentTriggerAcceptsTheOppositeModifierSide() throws {
@@ -166,13 +122,8 @@ struct KeybindResolverTests {
             actions: [[keyA]: action]
         )
 
-        try expectAction(
-            decision,
-            action: action,
-            source: .trigger,
-            category: .nonRepeatable,
-            activation: .activate
-        )
+        try expectOpen(decision.effect, action: action, overridesDelayAction: true)
+        #expect(decision.handling == .consumeIfLoopOpenOtherwiseOpening)
     }
 
     @Test func sideDependentTriggerRejectsTheOppositeModifierSide() {
@@ -185,7 +136,6 @@ struct KeybindResolverTests {
             actions: [[keyA]: action]
         )
 
-        #expect(decision.match == .none)
         #expect(decision.effect == .close(force: false, notifyDoubleClickKeyUp: false))
         #expect(decision.handling == .forward)
     }
@@ -196,7 +146,6 @@ struct KeybindResolverTests {
             pressedKeys: [.kVK_Escape]
         )
 
-        #expect(decision.match == .escape)
         #expect(decision.effect == .close(force: true, notifyDoubleClickKeyUp: false))
         #expect(decision.handling == .consume)
     }
@@ -208,7 +157,6 @@ struct KeybindResolverTests {
             modifierKeys: []
         )
 
-        #expect(decision.match == .triggerReleasedWhileOpen)
         #expect(decision.effect == .close(force: false, notifyDoubleClickKeyUp: false))
         #expect(decision.handling == .forward)
     }
@@ -220,7 +168,6 @@ struct KeybindResolverTests {
             isLoopOpen: false
         )
 
-        #expect(decision.match == .triggerOnly)
         let opened = try #require(openEffect(decision.effect))
         #expect(opened.action.direction == .noSelection)
         #expect(opened.overridesDelayAction)
@@ -235,7 +182,6 @@ struct KeybindResolverTests {
             isLoopOpen: false
         )
 
-        #expect(decision.match == .none)
         #expect(decision.effect == .close(force: false, notifyDoubleClickKeyUp: true))
         #expect(decision.handling == .forward)
     }
@@ -267,20 +213,6 @@ struct KeybindResolverTests {
         )
     }
 
-    private func expectAction(
-        _ decision: KeybindResolver.Decision,
-        action expectedAction: WindowAction,
-        source expectedSource: KeybindResolver.ActionSource,
-        category expectedCategory: KeybindResolver.ActionCategory,
-        activation expectedActivation: KeybindResolver.Activation
-    ) throws {
-        let match = try #require(actionMatch(decision.match))
-        #expect(match.action.id == expectedAction.id)
-        #expect(match.source == expectedSource)
-        #expect(match.category == expectedCategory)
-        #expect(match.activation == expectedActivation)
-    }
-
     private func expectOpen(
         _ effect: KeybindResolver.Effect,
         action expectedAction: WindowAction,
@@ -289,20 +221,6 @@ struct KeybindResolverTests {
         let open = try #require(openEffect(effect))
         #expect(open.action.id == expectedAction.id)
         #expect(open.overridesDelayAction == overridesDelayAction)
-    }
-
-    private func actionMatch(
-        _ match: KeybindResolver.Match
-    ) -> (
-        action: WindowAction,
-        source: KeybindResolver.ActionSource,
-        category: KeybindResolver.ActionCategory,
-        activation: KeybindResolver.Activation
-    )? {
-        guard case let .action(action, source, category, activation) = match else {
-            return nil
-        }
-        return (action, source, category, activation)
     }
 
     private func openEffect(

--- a/LoopTests/KeybindResolverTests.swift
+++ b/LoopTests/KeybindResolverTests.swift
@@ -63,9 +63,9 @@ struct KeybindResolverTests {
             category: .cycle,
             activation: .activate
         )
-        #expect(isNoMatch(chordKeyUp.match))
-        #expect(hasNoEffect(chordKeyUp.effect))
-        #expect(isForward(chordKeyUp.handling))
+        #expect(chordKeyUp.match == .none)
+        #expect(chordKeyUp.effect == .none)
+        #expect(chordKeyUp.handling == .forward)
         try expectAction(
             chordRepressed,
             action: chordCycle,
@@ -94,8 +94,8 @@ struct KeybindResolverTests {
             category: .cycle,
             activation: .suppressAutorepeat
         )
-        #expect(hasNoEffect(decision.effect))
-        #expect(isConsumeIfOpen(decision.handling))
+        #expect(decision.effect == .none)
+        #expect(decision.handling == .consumeIfLoopOpenOtherwiseOpening)
     }
 
     @Test func nonRepeatableActionAutorepeatIsSuppressed() throws {
@@ -114,7 +114,7 @@ struct KeybindResolverTests {
             category: .nonRepeatable,
             activation: .suppressAutorepeat
         )
-        #expect(hasNoEffect(decision.effect))
+        #expect(decision.effect == .none)
     }
 
     @Test func repeatableActionActivatesOnAutorepeat() throws {
@@ -185,9 +185,9 @@ struct KeybindResolverTests {
             actions: [[keyA]: action]
         )
 
-        #expect(isNoMatch(decision.match))
-        #expect(isGracefulClose(decision.effect, notifiesDoubleClick: false))
-        #expect(isForward(decision.handling))
+        #expect(decision.match == .none)
+        #expect(decision.effect == .close(force: false, notifyDoubleClickKeyUp: false))
+        #expect(decision.handling == .forward)
     }
 
     @Test func escapeForceClosesAnOpenSession() {
@@ -196,9 +196,9 @@ struct KeybindResolverTests {
             pressedKeys: [.kVK_Escape]
         )
 
-        #expect(isEscape(decision.match))
-        #expect(isForcedClose(decision.effect))
-        #expect(isConsume(decision.handling))
+        #expect(decision.match == .escape)
+        #expect(decision.effect == .close(force: true, notifyDoubleClickKeyUp: false))
+        #expect(decision.handling == .consume)
     }
 
     @Test func triggerReleaseGracefullyClosesAnOpenSession() {
@@ -208,9 +208,9 @@ struct KeybindResolverTests {
             modifierKeys: []
         )
 
-        #expect(isTriggerRelease(decision.match))
-        #expect(isGracefulClose(decision.effect, notifiesDoubleClick: false))
-        #expect(isForward(decision.handling))
+        #expect(decision.match == .triggerReleasedWhileOpen)
+        #expect(decision.effect == .close(force: false, notifyDoubleClickKeyUp: false))
+        #expect(decision.handling == .forward)
     }
 
     @Test func triggerAloneOpensWithoutASelectedAction() throws {
@@ -220,11 +220,11 @@ struct KeybindResolverTests {
             isLoopOpen: false
         )
 
-        #expect(isTriggerOnly(decision.match))
+        #expect(decision.match == .triggerOnly)
         let opened = try #require(openEffect(decision.effect))
         #expect(opened.action.direction == .noSelection)
         #expect(opened.overridesDelayAction)
-        #expect(isOpening(decision.handling))
+        #expect(decision.handling == .opening)
     }
 
     @Test func emptyUnmatchedInputNotifiesTheDoubleClickTimer() {
@@ -235,9 +235,9 @@ struct KeybindResolverTests {
             isLoopOpen: false
         )
 
-        #expect(isNoMatch(decision.match))
-        #expect(isGracefulClose(decision.effect, notifiesDoubleClick: true))
-        #expect(isForward(decision.handling))
+        #expect(decision.match == .none)
+        #expect(decision.effect == .close(force: false, notifyDoubleClickKeyUp: true))
+        #expect(decision.handling == .forward)
     }
 
     private func resolve(
@@ -312,60 +312,5 @@ struct KeybindResolverTests {
             return nil
         }
         return (action, overridesDelayAction)
-    }
-
-    private func isNoMatch(_ match: KeybindResolver.Match) -> Bool {
-        if case .none = match { true } else { false }
-    }
-
-    private func isEscape(_ match: KeybindResolver.Match) -> Bool {
-        if case .escape = match { true } else { false }
-    }
-
-    private func isTriggerRelease(_ match: KeybindResolver.Match) -> Bool {
-        if case .triggerReleasedWhileOpen = match { true } else { false }
-    }
-
-    private func isTriggerOnly(_ match: KeybindResolver.Match) -> Bool {
-        if case .triggerOnly = match { true } else { false }
-    }
-
-    private func hasNoEffect(_ effect: KeybindResolver.Effect) -> Bool {
-        if case .none = effect { true } else { false }
-    }
-
-    private func isForcedClose(_ effect: KeybindResolver.Effect) -> Bool {
-        if case let .close(force, notifyDoubleClickKeyUp) = effect {
-            force && !notifyDoubleClickKeyUp
-        } else {
-            false
-        }
-    }
-
-    private func isGracefulClose(
-        _ effect: KeybindResolver.Effect,
-        notifiesDoubleClick: Bool
-    ) -> Bool {
-        if case let .close(force, notifyDoubleClickKeyUp) = effect {
-            !force && notifyDoubleClickKeyUp == notifiesDoubleClick
-        } else {
-            false
-        }
-    }
-
-    private func isForward(_ handling: KeybindResolver.HandlingIntent) -> Bool {
-        if case .forward = handling { true } else { false }
-    }
-
-    private func isConsume(_ handling: KeybindResolver.HandlingIntent) -> Bool {
-        if case .consume = handling { true } else { false }
-    }
-
-    private func isOpening(_ handling: KeybindResolver.HandlingIntent) -> Bool {
-        if case .opening = handling { true } else { false }
-    }
-
-    private func isConsumeIfOpen(_ handling: KeybindResolver.HandlingIntent) -> Bool {
-        if case .consumeIfLoopOpenOtherwiseOpening = handling { true } else { false }
     }
 }

--- a/LoopTests/KeybindResolverTests.swift
+++ b/LoopTests/KeybindResolverTests.swift
@@ -1,0 +1,371 @@
+//
+//  KeybindResolverTests.swift
+//  LoopTests
+//
+//  Created by Kai Azim on 2026-08-29.
+//
+
+import CoreGraphics
+@testable import Loop
+import Testing
+
+struct KeybindResolverTests {
+    private let triggerKey: Set<CGKeyCode> = [.kVK_Control]
+    private let keyA: CGKeyCode = .kVK_LeftArrow
+    private let keyB: CGKeyCode = .kVK_RightArrow
+
+    @Test func overlappingChordReactivatesWithoutMatchingItsSubsetOnKeyUp() throws {
+        let singleCycle = WindowAction([
+            .init(.leftHalf),
+            .init(.rightHalf)
+        ])
+        let chordCycle = WindowAction([
+            .init(.topHalf),
+            .init(.bottomHalf)
+        ])
+        let actions: [Set<CGKeyCode>: WindowAction] = [
+            [keyA]: singleCycle,
+            [keyA, keyB]: chordCycle
+        ]
+
+        let singleDown = resolve(
+            eventType: .keyDown,
+            pressedKeys: [keyA],
+            actions: actions
+        )
+        let chordDown = resolve(
+            eventType: .keyDown,
+            pressedKeys: [keyA, keyB],
+            actions: actions
+        )
+        let chordKeyUp = resolve(
+            eventType: .keyUp,
+            pressedKeys: [keyA],
+            actions: actions
+        )
+        let chordRepressed = resolve(
+            eventType: .keyDown,
+            pressedKeys: [keyA, keyB],
+            actions: actions
+        )
+
+        try expectAction(
+            singleDown,
+            action: singleCycle,
+            source: .trigger,
+            category: .cycle,
+            activation: .activate
+        )
+        try expectAction(
+            chordDown,
+            action: chordCycle,
+            source: .trigger,
+            category: .cycle,
+            activation: .activate
+        )
+        #expect(isNoMatch(chordKeyUp.match))
+        #expect(hasNoEffect(chordKeyUp.effect))
+        #expect(isForward(chordKeyUp.handling))
+        try expectAction(
+            chordRepressed,
+            action: chordCycle,
+            source: .trigger,
+            category: .cycle,
+            activation: .activate
+        )
+    }
+
+    @Test func cycleAutorepeatIsSuppressed() throws {
+        let cycle = WindowAction([
+            .init(.leftHalf),
+            .init(.rightHalf)
+        ])
+        let decision = resolve(
+            eventType: .keyDown,
+            isRepeat: true,
+            pressedKeys: [keyA],
+            actions: [[keyA]: cycle]
+        )
+
+        try expectAction(
+            decision,
+            action: cycle,
+            source: .trigger,
+            category: .cycle,
+            activation: .suppressAutorepeat
+        )
+        #expect(hasNoEffect(decision.effect))
+        #expect(isConsumeIfOpen(decision.handling))
+    }
+
+    @Test func nonRepeatableActionAutorepeatIsSuppressed() throws {
+        let action = WindowAction(.leftHalf)
+        let decision = resolve(
+            eventType: .keyDown,
+            isRepeat: true,
+            pressedKeys: [keyA],
+            actions: [[keyA]: action]
+        )
+
+        try expectAction(
+            decision,
+            action: action,
+            source: .trigger,
+            category: .nonRepeatable,
+            activation: .suppressAutorepeat
+        )
+        #expect(hasNoEffect(decision.effect))
+    }
+
+    @Test func repeatableActionActivatesOnAutorepeat() throws {
+        let action = WindowAction(.larger)
+        let decision = resolve(
+            eventType: .keyDown,
+            isRepeat: true,
+            pressedKeys: [keyA],
+            actions: [[keyA]: action]
+        )
+
+        try expectAction(
+            decision,
+            action: action,
+            source: .trigger,
+            category: .repeatableNonCycle,
+            activation: .activate
+        )
+        try expectOpen(decision.effect, action: action, overridesDelayAction: true)
+    }
+
+    @Test func bypassActionActivatesWithoutTheTriggerKey() throws {
+        let action = WindowAction(.rightHalf)
+        let decision = resolve(
+            eventType: .keyDown,
+            pressedKeys: [keyA],
+            modifierKeys: [],
+            isLoopOpen: false,
+            bypassedActions: [[keyA]: action]
+        )
+
+        try expectAction(
+            decision,
+            action: action,
+            source: .bypassTrigger,
+            category: .nonRepeatable,
+            activation: .activate
+        )
+        try expectOpen(decision.effect, action: action, overridesDelayAction: true)
+    }
+
+    @Test func sideIndependentTriggerAcceptsTheOppositeModifierSide() throws {
+        let action = WindowAction(.leftHalf)
+        let decision = resolve(
+            eventType: .keyDown,
+            pressedKeys: [keyA],
+            modifierKeys: [.kVK_RightControl],
+            isSideDependent: false,
+            actions: [[keyA]: action]
+        )
+
+        try expectAction(
+            decision,
+            action: action,
+            source: .trigger,
+            category: .nonRepeatable,
+            activation: .activate
+        )
+    }
+
+    @Test func sideDependentTriggerRejectsTheOppositeModifierSide() {
+        let action = WindowAction(.leftHalf)
+        let decision = resolve(
+            eventType: .keyDown,
+            pressedKeys: [keyA],
+            modifierKeys: [.kVK_RightControl],
+            isSideDependent: true,
+            actions: [[keyA]: action]
+        )
+
+        #expect(isNoMatch(decision.match))
+        #expect(isGracefulClose(decision.effect, notifiesDoubleClick: false))
+        #expect(isForward(decision.handling))
+    }
+
+    @Test func escapeForceClosesAnOpenSession() {
+        let decision = resolve(
+            eventType: .keyDown,
+            pressedKeys: [.kVK_Escape]
+        )
+
+        #expect(isEscape(decision.match))
+        #expect(isForcedClose(decision.effect))
+        #expect(isConsume(decision.handling))
+    }
+
+    @Test func triggerReleaseGracefullyClosesAnOpenSession() {
+        let decision = resolve(
+            eventType: .flagsChanged,
+            pressedKeys: [],
+            modifierKeys: []
+        )
+
+        #expect(isTriggerRelease(decision.match))
+        #expect(isGracefulClose(decision.effect, notifiesDoubleClick: false))
+        #expect(isForward(decision.handling))
+    }
+
+    @Test func triggerAloneOpensWithoutASelectedAction() throws {
+        let decision = resolve(
+            eventType: .flagsChanged,
+            pressedKeys: [],
+            isLoopOpen: false
+        )
+
+        #expect(isTriggerOnly(decision.match))
+        let opened = try #require(openEffect(decision.effect))
+        #expect(opened.action.direction == .noSelection)
+        #expect(opened.overridesDelayAction)
+        #expect(isOpening(decision.handling))
+    }
+
+    @Test func emptyUnmatchedInputNotifiesTheDoubleClickTimer() {
+        let decision = resolve(
+            eventType: .flagsChanged,
+            pressedKeys: [],
+            modifierKeys: [],
+            isLoopOpen: false
+        )
+
+        #expect(isNoMatch(decision.match))
+        #expect(isGracefulClose(decision.effect, notifiesDoubleClick: true))
+        #expect(isForward(decision.handling))
+    }
+
+    private func resolve(
+        eventType: KeybindResolver.EventType,
+        isRepeat: Bool = false,
+        pressedKeys: Set<CGKeyCode>,
+        modifierKeys: Set<CGKeyCode>? = nil,
+        isSideDependent: Bool = false,
+        isLoopOpen: Bool = true,
+        actions: [Set<CGKeyCode>: WindowAction] = [:],
+        bypassedActions: [Set<CGKeyCode>: WindowAction] = [:]
+    ) -> KeybindResolver.Decision {
+        KeybindResolver.resolve(
+            .init(
+                eventType: eventType,
+                isRepeat: isRepeat,
+                pressedKeys: pressedKeys,
+                modifierKeys: modifierKeys ?? triggerKey,
+                trigger: .init(
+                    keys: triggerKey,
+                    isSideDependent: isSideDependent
+                ),
+                isLoopOpen: isLoopOpen,
+                actionsByKeybind: actions,
+                bypassedActionsByKeybind: bypassedActions
+            )
+        )
+    }
+
+    private func expectAction(
+        _ decision: KeybindResolver.Decision,
+        action expectedAction: WindowAction,
+        source expectedSource: KeybindResolver.ActionSource,
+        category expectedCategory: KeybindResolver.ActionCategory,
+        activation expectedActivation: KeybindResolver.Activation
+    ) throws {
+        let match = try #require(actionMatch(decision.match))
+        #expect(match.action.id == expectedAction.id)
+        #expect(match.source == expectedSource)
+        #expect(match.category == expectedCategory)
+        #expect(match.activation == expectedActivation)
+    }
+
+    private func expectOpen(
+        _ effect: KeybindResolver.Effect,
+        action expectedAction: WindowAction,
+        overridesDelayAction: Bool
+    ) throws {
+        let open = try #require(openEffect(effect))
+        #expect(open.action.id == expectedAction.id)
+        #expect(open.overridesDelayAction == overridesDelayAction)
+    }
+
+    private func actionMatch(
+        _ match: KeybindResolver.Match
+    ) -> (
+        action: WindowAction,
+        source: KeybindResolver.ActionSource,
+        category: KeybindResolver.ActionCategory,
+        activation: KeybindResolver.Activation
+    )? {
+        guard case let .action(action, source, category, activation) = match else {
+            return nil
+        }
+        return (action, source, category, activation)
+    }
+
+    private func openEffect(
+        _ effect: KeybindResolver.Effect
+    ) -> (action: WindowAction, overridesDelayAction: Bool)? {
+        guard case let .open(action, overridesDelayAction) = effect else {
+            return nil
+        }
+        return (action, overridesDelayAction)
+    }
+
+    private func isNoMatch(_ match: KeybindResolver.Match) -> Bool {
+        if case .none = match { true } else { false }
+    }
+
+    private func isEscape(_ match: KeybindResolver.Match) -> Bool {
+        if case .escape = match { true } else { false }
+    }
+
+    private func isTriggerRelease(_ match: KeybindResolver.Match) -> Bool {
+        if case .triggerReleasedWhileOpen = match { true } else { false }
+    }
+
+    private func isTriggerOnly(_ match: KeybindResolver.Match) -> Bool {
+        if case .triggerOnly = match { true } else { false }
+    }
+
+    private func hasNoEffect(_ effect: KeybindResolver.Effect) -> Bool {
+        if case .none = effect { true } else { false }
+    }
+
+    private func isForcedClose(_ effect: KeybindResolver.Effect) -> Bool {
+        if case let .close(force, notifyDoubleClickKeyUp) = effect {
+            force && !notifyDoubleClickKeyUp
+        } else {
+            false
+        }
+    }
+
+    private func isGracefulClose(
+        _ effect: KeybindResolver.Effect,
+        notifiesDoubleClick: Bool
+    ) -> Bool {
+        if case let .close(force, notifyDoubleClickKeyUp) = effect {
+            !force && notifyDoubleClickKeyUp == notifiesDoubleClick
+        } else {
+            false
+        }
+    }
+
+    private func isForward(_ handling: KeybindResolver.HandlingIntent) -> Bool {
+        if case .forward = handling { true } else { false }
+    }
+
+    private func isConsume(_ handling: KeybindResolver.HandlingIntent) -> Bool {
+        if case .consume = handling { true } else { false }
+    }
+
+    private func isOpening(_ handling: KeybindResolver.HandlingIntent) -> Bool {
+        if case .opening = handling { true } else { false }
+    }
+
+    private func isConsumeIfOpen(_ handling: KeybindResolver.HandlingIntent) -> Bool {
+        if case .consumeIfLoopOpenOtherwiseOpening = handling { true } else { false }
+    }
+}

--- a/LoopTests/OverlappingKeybindCycleTests.swift
+++ b/LoopTests/OverlappingKeybindCycleTests.swift
@@ -163,30 +163,17 @@ struct OverlappingKeybindCycleTests {
                 )
             )
             let cycleAction = try #require(matchedCycleAction(decision.match))
-            let children = try #require(cycleAction.cycle)
-            let currentActionBelongsToCycle = children.contains { $0.id == resizeContext.action.id }
-            let restartAtBeginning = CycleProgressStore.shouldRestartAtBeginning(
-                whenEnabled: true,
-                currentAction: resizeContext.action,
-                currentParentAction: resizeContext.parentAction,
-                keybindSequenceOriginAction: resizeContext.keybindSequenceOriginAction,
-                in: cycleAction
-            )
-            let seedAction = restartAtBeginning
-                ? nil
-                : currentActionBelongsToCycle ? resizeContext.action : nil
-            let proposedSelection = resizeContext.proposeCycleSelection(
+            let proposedAction = resizeContext.proposeCycleAction(
                 in: cycleAction,
-                seededBy: seedAction,
-                restartAtBeginning: restartAtBeginning,
+                restartAtBeginningWhenInterrupted: true,
                 direction: .forward
             )
-            let selection = try #require(proposedSelection)
-            let accepted = resizeContext.acceptCycleSelection(selection, in: cycleAction)
+            let proposal = try #require(proposedAction)
+            let committedAction = resizeContext.commitCycleAction(proposal, in: cycleAction)
+            let action = try #require(committedAction)
 
-            #expect(accepted)
-            resizeContext.setAction(to: selection.action, parent: cycleAction)
-            return selection.action
+            resizeContext.setAction(to: action, parent: cycleAction)
+            return action
         }
 
         private func matchedCycleAction(_ match: KeybindResolver.Match) -> WindowAction? {

--- a/LoopTests/OverlappingKeybindCycleTests.swift
+++ b/LoopTests/OverlappingKeybindCycleTests.swift
@@ -1,0 +1,199 @@
+//
+//  OverlappingKeybindCycleTests.swift
+//  LoopTests
+//
+//  Created by Kai Azim on 2026-08-29.
+//
+
+import CoreGraphics
+@testable import Loop
+import Testing
+
+struct OverlappingKeybindCycleTests {
+    private let triggerKey: Set<CGKeyCode> = [.kVK_Control]
+    private let firstKey: CGKeyCode = .kVK_LeftArrow
+    private let secondKey: CGKeyCode = .kVK_RightArrow
+    private let thirdKey: CGKeyCode = .kVK_DownArrow
+    private let unrelatedKey: CGKeyCode = .kVK_UpArrow
+
+    @Test func dualKeyCycleAdvancesWhenItsPrefixIsAlsoBound() throws {
+        var fixture = makeDualKeyFixture()
+
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        let firstSelection = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        let secondSelection = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+
+        #expect(firstSelection.id == fixture.firstChordAction.id)
+        #expect(secondSelection.id == fixture.secondChordAction.id)
+    }
+
+    @Test func dualKeyCycleRestartsAfterAnUnrelatedCycle() throws {
+        var fixture = makeDualKeyFixture()
+
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        let secondSelection = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+        _ = try fixture.scenario.activate(pressedKeys: [unrelatedKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        let restartedSelection = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+
+        #expect(secondSelection.id == fixture.secondChordAction.id)
+        #expect(restartedSelection.id == fixture.firstChordAction.id)
+    }
+
+    @Test func tripleKeyCycleAdvancesWhenEachPrefixIsBound() throws {
+        var fixture = makeTripleKeyFixture()
+
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+        let firstSelection = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey, thirdKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey])
+        _ = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey])
+        let secondSelection = try fixture.scenario.activate(pressedKeys: [firstKey, secondKey, thirdKey])
+
+        #expect(firstSelection.id == fixture.firstChordAction.id)
+        #expect(secondSelection.id == fixture.secondChordAction.id)
+    }
+
+    private func makeDualKeyFixture() -> Fixture {
+        let prefixCycle = WindowAction(
+            cycle: [
+                .init(.leftHalf),
+                .init(.rightHalf)
+            ],
+            keybind: [firstKey]
+        )
+        let firstChordAction = WindowAction(.topHalf)
+        let secondChordAction = WindowAction(.bottomHalf)
+        let chordCycle = WindowAction(
+            cycle: [
+                firstChordAction,
+                secondChordAction
+            ],
+            keybind: [firstKey, secondKey]
+        )
+        let unrelatedCycle = WindowAction(
+            cycle: [
+                .init(.topLeftQuarter),
+                .init(.bottomRightQuarter)
+            ],
+            keybind: [unrelatedKey]
+        )
+        let actions: [Set<CGKeyCode>: WindowAction] = [
+            [firstKey]: prefixCycle,
+            [firstKey, secondKey]: chordCycle,
+            [unrelatedKey]: unrelatedCycle
+        ]
+
+        return Fixture(
+            scenario: Scenario(
+                triggerKey: triggerKey,
+                actions: actions
+            ),
+            firstChordAction: firstChordAction,
+            secondChordAction: secondChordAction
+        )
+    }
+
+    private func makeTripleKeyFixture() -> Fixture {
+        let prefixCycle = WindowAction(
+            cycle: [
+                .init(.leftHalf),
+                .init(.rightHalf)
+            ],
+            keybind: [firstKey]
+        )
+        let intermediateCycle = WindowAction(
+            cycle: [
+                .init(.topLeftQuarter),
+                .init(.bottomRightQuarter)
+            ],
+            keybind: [firstKey, secondKey]
+        )
+        let firstChordAction = WindowAction(.topHalf)
+        let secondChordAction = WindowAction(.bottomHalf)
+        let chordCycle = WindowAction(
+            cycle: [
+                firstChordAction,
+                secondChordAction
+            ],
+            keybind: [firstKey, secondKey, thirdKey]
+        )
+        let actions: [Set<CGKeyCode>: WindowAction] = [
+            [firstKey]: prefixCycle,
+            [firstKey, secondKey]: intermediateCycle,
+            [firstKey, secondKey, thirdKey]: chordCycle
+        ]
+
+        return Fixture(
+            scenario: Scenario(
+                triggerKey: triggerKey,
+                actions: actions
+            ),
+            firstChordAction: firstChordAction,
+            secondChordAction: secondChordAction
+        )
+    }
+
+    private struct Fixture {
+        var scenario: Scenario
+        let firstChordAction: WindowAction
+        let secondChordAction: WindowAction
+    }
+
+    private struct Scenario {
+        let triggerKey: Set<CGKeyCode>
+        let actions: [Set<CGKeyCode>: WindowAction]
+
+        var resizeContext = ResizeContext()
+
+        mutating func activate(pressedKeys: Set<CGKeyCode>) throws -> WindowAction {
+            let decision = KeybindResolver.resolve(
+                .init(
+                    eventType: .keyDown,
+                    isRepeat: false,
+                    pressedKeys: pressedKeys,
+                    modifierKeys: triggerKey,
+                    trigger: .init(keys: triggerKey, isSideDependent: false),
+                    isLoopOpen: true,
+                    actionsByKeybind: actions,
+                    bypassedActionsByKeybind: [:]
+                )
+            )
+            let cycleAction = try #require(matchedCycleAction(decision.match))
+            let children = try #require(cycleAction.cycle)
+            let currentActionBelongsToCycle = children.contains { $0.id == resizeContext.action.id }
+            let restartAtBeginning = CycleProgressStore.shouldRestartAtBeginning(
+                whenEnabled: true,
+                currentAction: resizeContext.action,
+                currentParentAction: resizeContext.parentAction,
+                keybindSequenceOriginAction: resizeContext.keybindSequenceOriginAction,
+                in: cycleAction
+            )
+            let seedAction = restartAtBeginning
+                ? nil
+                : currentActionBelongsToCycle ? resizeContext.action : nil
+            let proposedSelection = resizeContext.proposeCycleSelection(
+                in: cycleAction,
+                seededBy: seedAction,
+                restartAtBeginning: restartAtBeginning,
+                direction: .forward
+            )
+            let selection = try #require(proposedSelection)
+            let accepted = resizeContext.acceptCycleSelection(selection, in: cycleAction)
+
+            #expect(accepted)
+            resizeContext.setAction(to: selection.action, parent: cycleAction)
+            return selection.action
+        }
+
+        private func matchedCycleAction(_ match: KeybindResolver.Match) -> WindowAction? {
+            guard case let .action(action, _, .cycle, .activate) = match else {
+                return nil
+            }
+            return action
+        }
+    }
+}

--- a/LoopTests/OverlappingKeybindCycleTests.swift
+++ b/LoopTests/OverlappingKeybindCycleTests.swift
@@ -173,7 +173,7 @@ struct OverlappingKeybindCycleTests {
             let proposedAction = resizeContext.proposeCycleAction(
                 in: cycleAction,
                 restartAtBeginningWhenInterrupted: true,
-                direction: .forward
+                mode: .advance(.forward)
             )
             let proposal = try #require(proposedAction)
             let committedAction = resizeContext.commitCycleAction(proposal, in: cycleAction)

--- a/LoopTests/OverlappingKeybindCycleTests.swift
+++ b/LoopTests/OverlappingKeybindCycleTests.swift
@@ -162,7 +162,14 @@ struct OverlappingKeybindCycleTests {
                     bypassedActionsByKeybind: [:]
                 )
             )
-            let cycleAction = try #require(matchedCycleAction(decision.match))
+            let matchedAction = try #require(openedAction(decision.effect))
+
+            guard matchedAction.direction == .cycle else {
+                resizeContext.setAction(to: matchedAction, parent: nil)
+                return matchedAction
+            }
+
+            let cycleAction = matchedAction
             let proposedAction = resizeContext.proposeCycleAction(
                 in: cycleAction,
                 restartAtBeginningWhenInterrupted: true,
@@ -176,8 +183,10 @@ struct OverlappingKeybindCycleTests {
             return action
         }
 
-        private func matchedCycleAction(_ match: KeybindResolver.Match) -> WindowAction? {
-            guard case let .action(action, _, .cycle, .activate) = match else {
+        private func openedAction(
+            _ effect: KeybindResolver.Effect
+        ) -> WindowAction? {
+            guard case let .open(action, _) = effect else {
                 return nil
             }
             return action


### PR DESCRIPTION
Fixes cycle progression so each cycle keeps its own position for each target window. Previously, Loop inferred progress from the current resize action, which could cause cycles to interfere with one another. It also made multi-key cycles repeatedly select their first action when "Always start cycles from first item" was enabled and a shorter prefix was also bound.

Cycle selection now lives in a dedicated `CycleActionCoordinator`, backed by a `CycleProgressStore` keyed by the target window and parent cycle. The coordinator handles restart behavior, overlapping key sequences, and selecting/committing actions, while the store keeps progress stable using child action IDs.

This also extracts keybind matching into `KeybindResolver` and adds a `LoopTests` target covering cycle progress, keybind handling, and overlapping multi-key cycles :)