### PR TITLE
feat: Add option to trigger Loop via right-click while dragging a window

### DIFF
--- a/.github/workflows/build-adhoc.yml
+++ b/.github/workflows/build-adhoc.yml
@@ -19,6 +19,8 @@ jobs:
             -destination 'generic/platform=macOS' \
             -configuration Release \
             -derivedDataPath build \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO || true

--- a/.github/workflows/build-adhoc.yml
+++ b/.github/workflows/build-adhoc.yml
@@ -1,0 +1,45 @@
+name: Build Ad-Hoc Loop
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Ad-Hoc
+    runs-on: macos-latest
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🛠️ Build Loop
+        run: |
+          mkdir -p dist
+          set -o pipefail && xcodebuild \
+            archive \
+            -project Loop.xcodeproj/ \
+            -scheme "Loop" \
+            -destination 'generic/platform=macOS' \
+            -archivePath dist/Loop.xcarchive \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify || true
+
+      - name: 🥡 Export Loop.app
+        run: |
+          # Since we aren't code signing, we might not be able to use -exportArchive easily.
+          # The .app is already inside the xcarchive!
+          cp -r dist/Loop.xcarchive/Products/Applications/Loop.app dist/Loop.app
+
+      - name: ✍️ Ad-Hoc Code Sign
+        run: |
+          codesign --force --deep --sign - dist/Loop.app
+
+      - name: 🤏 Compress Loop
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent "dist/Loop.app" "dist/Loop.zip"
+
+      - name: ⬆️ Upload Loop
+        uses: actions/upload-artifact@v4
+        with:
+          name: Loop-Custom-Build
+          path: dist/Loop.zip

--- a/.github/workflows/build-adhoc.yml
+++ b/.github/workflows/build-adhoc.yml
@@ -12,31 +12,26 @@ jobs:
 
       - name: 🛠️ Build Loop
         run: |
-          mkdir -p dist
           set -o pipefail && xcodebuild \
-            archive \
+            build \
             -project Loop.xcodeproj/ \
             -scheme "Loop" \
             -destination 'generic/platform=macOS' \
-            -archivePath dist/Loop.xcarchive \
+            -configuration Release \
+            -derivedDataPath build \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             | xcbeautify || true
 
-      - name: 🥡 Export Loop.app
-        run: |
-          # Since we aren't code signing, we might not be able to use -exportArchive easily.
-          # The .app is already inside the xcarchive!
-          cp -r dist/Loop.xcarchive/Products/Applications/Loop.app dist/Loop.app
-
       - name: ✍️ Ad-Hoc Code Sign
         run: |
-          codesign --force --deep --sign - dist/Loop.app
+          codesign --force --deep --sign - build/Build/Products/Release/Loop.app
 
       - name: 🤏 Compress Loop
         run: |
-          ditto -c -k --sequesterRsrc --keepParent "dist/Loop.app" "dist/Loop.zip"
+          mkdir -p dist
+          ditto -c -k --sequesterRsrc --keepParent "build/Build/Products/Release/Loop.app" "dist/Loop.zip"
 
       - name: ⬆️ Upload Loop
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-adhoc.yml
+++ b/.github/workflows/build-adhoc.yml
@@ -21,8 +21,7 @@ jobs:
             -derivedDataPath build \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            | xcbeautify || true
+            CODE_SIGNING_ALLOWED=NO || true
 
       - name: ✍️ Ad-Hoc Code Sign
         run: |

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -87,6 +87,20 @@ final class LoopManager {
         checkIfLoopOpen: { [weak self] in self?.isLoopActiveAtomic ?? false }
     )
 
+    private(set) lazy var rightClickWhileDraggingTrigger = RightClickWhileDraggingTrigger(
+        openCallback: { [weak self] action in
+            Task {
+                await self?.openLoop(startingAction: action)
+            }
+        },
+        closeCallback: { [weak self] forceClose in
+            Task {
+                await self?.closeLoop(forceClose: forceClose)
+            }
+        },
+        checkIfLoopOpen: { [weak self] in self?.isLoopActiveAtomic ?? false }
+    )
+
     private(set) lazy var mouseInteractionObserver = MouseInteractionObserver(
         windowActionCache: windowActionCache,
         changeAction: { [weak self] newAction in
@@ -119,9 +133,11 @@ final class LoopManager {
                 if status {
                     await keybindTrigger.start()
                     middleClickTrigger.start()
+                    rightClickWhileDraggingTrigger.start()
                 } else {
                     keybindTrigger.stop()
                     middleClickTrigger.stop()
+                    rightClickWhileDraggingTrigger.stop()
                 }
             }
         }
@@ -137,6 +153,7 @@ final class LoopManager {
 
         keybindTrigger.stop()
         middleClickTrigger.stop()
+        rightClickWhileDraggingTrigger.stop()
         mouseInteractionObserver.stop()
         triggerKeyTimeoutTimer.cancel()
 

--- a/Loop/Core/LoopManager.swift
+++ b/Loop/Core/LoopManager.swift
@@ -87,6 +87,7 @@ final class LoopManager {
         checkIfLoopOpen: { [weak self] in self?.isLoopActiveAtomic ?? false }
     )
 
+    /// The trigger responsible for reading right-click events when dragging a window.
     private(set) lazy var rightClickWhileDraggingTrigger = RightClickWhileDraggingTrigger(
         openCallback: { [weak self] action in
             Task {

--- a/Loop/Core/Observers/MiddleClickTrigger.swift
+++ b/Loop/Core/Observers/MiddleClickTrigger.swift
@@ -94,3 +94,82 @@ final class MiddleClickTrigger {
         }
     }
 }
+//
+//  RightClickWhileDraggingTrigger.swift
+//  Loop
+//
+
+import AppKit
+import Defaults
+import Scribe
+
+/// Reads right-click events using an ActiveEventMonitor, and triggers Loop open/close callbacks
+/// if the user is currently dragging a window (as determined by WindowDragManager).
+@Loggable
+final class RightClickWhileDraggingTrigger {
+    // Callbacks
+    private let openCallback: (WindowAction) -> ()
+    private let closeCallback: (Bool) -> ()
+    private let checkIfLoopOpen: () -> Bool
+
+    private var monitor: ActiveEventMonitor?
+
+    // Defaults
+    private var rightClickTriggersLoopWhileDragging: Bool { Defaults[.rightClickTriggersLoopWhileDragging] }
+
+    /// Initializes a ``RightClickWhileDraggingTrigger``.
+    /// - Parameters:
+    ///   - openCallback: what to do when the right mouse button is pressed while dragging, and Loop should be activated.
+    ///   - closeCallback: what to do when the right mouse button is released, and Loop should be closed.
+    init(
+        openCallback: @escaping (WindowAction) -> (),
+        closeCallback: @escaping (Bool) -> (),
+        checkIfLoopOpen: @escaping () -> Bool
+    ) {
+        self.openCallback = openCallback
+        self.closeCallback = closeCallback
+        self.checkIfLoopOpen = checkIfLoopOpen
+    }
+
+    func start() {
+        stop()
+
+        let monitor = ActiveEventMonitor(
+            "right_click_dragging_trigger",
+            events: [.rightMouseDown, .rightMouseUp],
+            callback: handleRightClick
+        )
+        monitor.start()
+
+        self.monitor = monitor
+    }
+
+    func stop() {
+        monitor?.stop()
+        monitor = nil
+    }
+
+    // MARK: Private
+
+    private func handleRightClick(_ event: CGEvent) -> ActiveEventMonitor.EventHandling {
+        guard rightClickTriggersLoopWhileDragging else { return .forward }
+
+        if event.type == .rightMouseDown {
+            if WindowDragManager.shared.isDraggingWindow {
+                Task { @MainActor in
+                    openCallback(.init(.noSelection))
+                }
+                return .ignore
+            }
+        } else if event.type == .rightMouseUp {
+            if checkIfLoopOpen() {
+                Task { @MainActor in
+                    closeCallback(false)
+                }
+                return .ignore
+            }
+        }
+
+        return .forward
+    }
+}

--- a/Loop/Core/Observers/MiddleClickTrigger.swift
+++ b/Loop/Core/Observers/MiddleClickTrigger.swift
@@ -117,10 +117,11 @@ final class RightClickWhileDraggingTrigger {
     // Defaults
     private var rightClickTriggersLoopWhileDragging: Bool { Defaults[.rightClickTriggersLoopWhileDragging] }
 
-    /// Initializes a ``RightClickWhileDraggingTrigger``.
+    /// Initializes a `RightClickWhileDraggingTrigger`.
     /// - Parameters:
-    ///   - openCallback: what to do when the right mouse button is pressed while dragging, and Loop should be activated.
-    ///   - closeCallback: what to do when the right mouse button is released, and Loop should be closed.
+    ///   - openCallback: A closure that is executed when the right mouse button is pressed while dragging, indicating Loop should be activated.
+    ///   - closeCallback: A closure that is executed when the right mouse button is released, indicating Loop should be closed.
+    ///   - checkIfLoopOpen: A closure that returns a Boolean value indicating whether Loop is currently open.
     init(
         openCallback: @escaping (WindowAction) -> (),
         closeCallback: @escaping (Bool) -> (),
@@ -131,6 +132,9 @@ final class RightClickWhileDraggingTrigger {
         self.checkIfLoopOpen = checkIfLoopOpen
     }
 
+    /// Starts the active event monitor to begin listening for right-click events.
+    ///
+    /// This method will stop any existing monitor before starting a new one.
     func start() {
         stop()
 
@@ -144,6 +148,7 @@ final class RightClickWhileDraggingTrigger {
         self.monitor = monitor
     }
 
+    /// Stops the active event monitor and stops listening for right-click events.
     func stop() {
         monitor?.stop()
         monitor = nil
@@ -151,6 +156,9 @@ final class RightClickWhileDraggingTrigger {
 
     // MARK: Private
 
+    /// Processes captured right-click events and triggers Loop actions if a window is being dragged.
+    /// - Parameter event: The captured `CGEvent` to process.
+    /// - Returns: An `ActiveEventMonitor.EventHandling` value indicating whether the event should be forwarded to the system or ignored (swallowed).
     private func handleRightClick(_ event: CGEvent) -> ActiveEventMonitor.EventHandling {
         guard rightClickTriggersLoopWhileDragging else { return .forward }
 

--- a/Loop/Core/Observers/MouseInteractionObserver.swift
+++ b/Loop/Core/Observers/MouseInteractionObserver.swift
@@ -77,7 +77,9 @@ final class MouseInteractionObserver {
             "mouse_movement_monitor",
             events: [
                 .mouseMoved, // switch action when mouse is moved
-                .otherMouseDragged // switch action when mouse is moved with the middle mouse button clicked
+                .leftMouseDragged, // switch action when mouse is moved with the left mouse button clicked (e.g. while dragging window)
+                .otherMouseDragged, // switch action when mouse is moved with the middle mouse button clicked
+                .rightMouseDragged // switch action when mouse is moved with the right mouse button clicked
             ],
             callback: processNewMouseLocation
         )

--- a/Loop/Core/WindowDragManager.swift
+++ b/Loop/Core/WindowDragManager.swift
@@ -142,22 +142,20 @@ final class WindowDragManager {
     }
 
     private func leftMouseUp(_: CGEvent) {
-        guard Defaults[.windowSnapping] else {
-            return
-        }
-
         Task {
-            previewController.close()
+            if Defaults[.windowSnapping] {
+                previewController.close()
 
-            if let context = resizeContext,
-               !context.action.direction.isNoOp,
-               let window = context.window,
-               let initialFrame = initialWindowFrame,
-               hasWindowMoved(window.frame, initialFrame) {
-                do {
-                    _ = try await WindowActionEngine.shared.apply(context: context)
-                } catch {
-                    log.error("Failed to snap window: \(error.localizedDescription)")
+                if let context = resizeContext,
+                   !context.action.direction.isNoOp,
+                   let window = context.window,
+                   let initialFrame = initialWindowFrame,
+                   hasWindowMoved(window.frame, initialFrame) {
+                    do {
+                        _ = try await WindowActionEngine.shared.apply(context: context)
+                    } catch {
+                        log.error("Failed to snap window: \(error.localizedDescription)")
+                    }
                 }
             }
 

--- a/Loop/Core/WindowDragManager.swift
+++ b/Loop/Core/WindowDragManager.swift
@@ -42,8 +42,11 @@ final class WindowDragManager {
             Defaults[.rightClickTriggersLoopWhileDragging]
     }
 
+    /// A thread-safe mirror of the current dragging state, used to provide synchronous access across threads.
     private let isDraggingWindowMirror = OSAllocatedUnfairLock<Bool>(initialState: false)
 
+    /// A Boolean value indicating whether the user is currently dragging a window by its title bar.
+    /// This property is thread-safe and can be accessed synchronously from any context.
     nonisolated var isDraggingWindow: Bool {
         isDraggingWindowMirror.withLock { $0 }
     }

--- a/Loop/Core/WindowDragManager.swift
+++ b/Loop/Core/WindowDragManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Defaults
+import os
 import Scribe
 import SwiftUI
 
@@ -37,7 +38,14 @@ final class WindowDragManager {
     private var shouldMonitorDragActions: Bool {
         Defaults[.windowSnapping] ||
             Defaults[.restoreWindowFrameOnDrag] ||
-            !Defaults[.stashManagerStashedWindows].isEmpty
+            !Defaults[.stashManagerStashedWindows].isEmpty ||
+            Defaults[.rightClickTriggersLoopWhileDragging]
+    }
+
+    private let isDraggingWindowMirror = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+    nonisolated var isDraggingWindow: Bool {
+        isDraggingWindowMirror.withLock { $0 }
     }
 
     func addObservers() {
@@ -182,6 +190,7 @@ final class WindowDragManager {
             )
             await context.refreshResolvedState()
             self.resizeContext = context
+            self.isDraggingWindowMirror.withLock { $0 = true }
 
             log.info("Determined window being dragged: \(window.description)")
         }
@@ -189,6 +198,7 @@ final class WindowDragManager {
 
     private func resetDragState() {
         resizeContext = nil
+        isDraggingWindowMirror.withLock { $0 = false }
         didFailToResolveDraggedWindow = false
         initialWindowFrame = nil
         determineDraggedWindowTask?.cancel()

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -66,6 +66,7 @@ extension Defaults.Keys {
     static let triggerDelay = Key<Double>("triggerDelay", default: 0, iCloud: true)
     static let doubleClickToTrigger = Key<Bool>("doubleClickToTrigger", default: false, iCloud: true)
     static let middleClickTriggersLoop = Key<Bool>("middleClickTriggersLoop", default: false, iCloud: true)
+    static let rightClickTriggersLoopWhileDragging = Key<Bool>("rightClickTriggersLoopWhileDragging", default: false, iCloud: true)
     static let enableTriggerDelayOnMiddleClick = Key<Bool>("enableTriggerDelayOnMiddleClick", default: false, iCloud: true)
     static let cycleBackwardsOnShiftPressed = Key<Bool>("cycleBackwardsOnShiftPressed", default: true, iCloud: true)
     static let keybinds = Key<[WindowAction]>("keybinds", default: WindowAction.defaultKeybinds, iCloud: true)

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -66,6 +66,8 @@ extension Defaults.Keys {
     static let triggerDelay = Key<Double>("triggerDelay", default: 0, iCloud: true)
     static let doubleClickToTrigger = Key<Bool>("doubleClickToTrigger", default: false, iCloud: true)
     static let middleClickTriggersLoop = Key<Bool>("middleClickTriggersLoop", default: false, iCloud: true)
+
+    /// A Boolean value indicating whether a right-click should trigger Loop when dragging a window.
     static let rightClickTriggersLoopWhileDragging = Key<Bool>("rightClickTriggersLoopWhileDragging", default: true, iCloud: true)
     static let enableTriggerDelayOnMiddleClick = Key<Bool>("enableTriggerDelayOnMiddleClick", default: false, iCloud: true)
     static let cycleBackwardsOnShiftPressed = Key<Bool>("cycleBackwardsOnShiftPressed", default: true, iCloud: true)

--- a/Loop/Extensions/Defaults+Extensions.swift
+++ b/Loop/Extensions/Defaults+Extensions.swift
@@ -66,7 +66,7 @@ extension Defaults.Keys {
     static let triggerDelay = Key<Double>("triggerDelay", default: 0, iCloud: true)
     static let doubleClickToTrigger = Key<Bool>("doubleClickToTrigger", default: false, iCloud: true)
     static let middleClickTriggersLoop = Key<Bool>("middleClickTriggersLoop", default: false, iCloud: true)
-    static let rightClickTriggersLoopWhileDragging = Key<Bool>("rightClickTriggersLoopWhileDragging", default: false, iCloud: true)
+    static let rightClickTriggersLoopWhileDragging = Key<Bool>("rightClickTriggersLoopWhileDragging", default: true, iCloud: true)
     static let enableTriggerDelayOnMiddleClick = Key<Bool>("enableTriggerDelayOnMiddleClick", default: false, iCloud: true)
     static let cycleBackwardsOnShiftPressed = Key<Bool>("cycleBackwardsOnShiftPressed", default: true, iCloud: true)
     static let keybinds = Key<[WindowAction]>("keybinds", default: WindowAction.defaultKeybinds, iCloud: true)

--- a/Loop/Settings Window/Settings/Keybinds/KeybindsConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/KeybindsConfigurationView.swift
@@ -86,7 +86,7 @@ struct KeybindsConfigurationView: View {
 
             LuminareToggle("Double-click to trigger", isOn: $doubleClickToTrigger)
             LuminareToggle("Middle-click to trigger", isOn: $middleClickTriggersLoop)
-            LuminareToggle("Trigger by Mouse right click while moving window", isOn: $rightClickTriggersLoopWhileDragging)
+            LuminareToggle("Right-click to trigger while moving window", isOn: $rightClickTriggersLoopWhileDragging)
 
             if showMiddleClickTriggerDelayOption {
                 LuminareToggle("Apply trigger delay on middle-click", isOn: $enableTriggerDelayOnMiddleClick)

--- a/Loop/Settings Window/Settings/Keybinds/KeybindsConfigurationView.swift
+++ b/Loop/Settings Window/Settings/Keybinds/KeybindsConfigurationView.swift
@@ -26,6 +26,7 @@ struct KeybindsConfigurationView: View {
     @Default(.cycleBackwardsOnShiftPressed) private var cycleBackwardsOnShiftPressed
     @Default(.doubleClickToTrigger) private var doubleClickToTrigger
     @Default(.middleClickTriggersLoop) private var middleClickTriggersLoop
+    @Default(.rightClickTriggersLoopWhileDragging) private var rightClickTriggersLoopWhileDragging
     @Default(.enableTriggerDelayOnMiddleClick) private var enableTriggerDelayOnMiddleClick
     @Default(.keybinds) private var keybinds
 
@@ -85,6 +86,7 @@ struct KeybindsConfigurationView: View {
 
             LuminareToggle("Double-click to trigger", isOn: $doubleClickToTrigger)
             LuminareToggle("Middle-click to trigger", isOn: $middleClickTriggersLoop)
+            LuminareToggle("Trigger by Mouse right click while moving window", isOn: $rightClickTriggersLoopWhileDragging)
 
             if showMiddleClickTriggerDelayOption {
                 LuminareToggle("Apply trigger delay on middle-click", isOn: $enableTriggerDelayOnMiddleClick)


### PR DESCRIPTION
## Description

This PR introduces a new, highly ergonomic way to trigger the Loop radial menu: **holding the right mouse button while dragging a window**. 

For users who already use their mouse to drag windows around, it's often more practical to just right-click to invoke Loop, rather than reaching for a keyboard keybind. 

**Changes included:**
- Added a new `RightClickWhileDraggingTrigger` which activates the Loop menu when a user right-clicks while `WindowDragManager.shared.isDraggingWindow` is active.
- Added a new configuration toggle in **Keybinds Settings**: `"Right-click to trigger while moving window"`, which is enabled by default.
- Fixed a bug in `WindowDragManager` where the drag state (`resizeContext` and `isDraggingWindowMirror`) was never reset on `leftMouseUp` if window snapping was disabled in settings. This previously caused the app to think a window was being dragged indefinitely after the first drag.
- Enhanced `MouseInteractionObserver` to track `.leftMouseDragged` and `.rightMouseDragged` events. Since macOS stops emitting `.mouseMoved` when mouse buttons are held, the radial menu direction selection was completely blind to mouse movements during a drag. Now, the radial menu smoothly tracks the cursor while dragging a window.

## How has this been tested?

- [x] Compiled the application and verified that clicking and dragging a window's title bar, followed by a right-click, successfully brings up the Loop radial menu.
- [x] Verified that moving the mouse while holding both buttons properly highlights the different direction sections in the radial menu.
- [x] Verified that releasing the right-click button closes the radial menu without affecting the window drag.
- [x] Tested with "Window Snapping" disabled to ensure the `WindowDragManager` drag state properly resets on mouse release, preventing regular right-clicks from accidentally triggering the Loop menu.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="629" height="632" alt="Screenshot 2026-09-06 at 17 49 44" src="https://github.com/user-attachments/assets/441228cd-e5b3-4a20-811a-9a493a9f25f4" />


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in this PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I collaborated with an AI coding assistant (Google Antigravity / Gemini) to write the Swift implementation for the new `RightClickWhileDraggingTrigger`, the settings UI additions, and the fixes to `WindowDragManager` and `MouseInteractionObserver`. I personally compiled, ran, and thoroughly manually tested all the resulting changes on my local macOS environment to ensure they work perfectly.